### PR TITLE
chore(diplomacy): commit and test-lock the rules engine

### DIFF
--- a/src/games/diplomacy/DiplomacyBoard.js
+++ b/src/games/diplomacy/DiplomacyBoard.js
@@ -994,6 +994,34 @@ export default class DiplomacyBoard {
     }
   }
 
+  // BFS a convoy route from `from` to `to` using only fleets that ordered this
+  // exact convoy and survived adjudication (not in `dislodgedLocs`). Used to
+  // fail a convoyed move whose convoying fleet(s) were dislodged.
+  _convoyPathSurvives(from, to, validOrders, dislodgedLocs) {
+    const convoyFleets = Object.entries(this.units)
+      .filter(([loc, unit]) => unit.type === 'fleet' && isSea(loc) && !dislodgedLocs.has(loc))
+      .filter(([loc]) => {
+        const order = validOrders[loc];
+        return order?.type === 'convoy' && order.from === from && order.to === to;
+      })
+      .map(([loc]) => loc);
+    const fleetSet = new Set(convoyFleets);
+    const starts = convoyFleets.filter(sea => FLEET_ADJACENCY[sea]?.includes(from));
+    if (starts.length === 0) return false;
+    const seen = new Set(starts);
+    const queue = [...starts];
+    while (queue.length) {
+      const sea = queue.shift();
+      if (FLEET_ADJACENCY[sea]?.includes(to)) return true;
+      for (const next of FLEET_ADJACENCY[sea] || []) {
+        if (!fleetSet.has(next) || seen.has(next)) continue;
+        seen.add(next);
+        queue.push(next);
+      }
+    }
+    return false;
+  }
+
   _adjudicate(ordersByLoc) {
     const validOrders = { ...ordersByLoc };
     for (const [loc, order] of Object.entries(validOrders)) {
@@ -1106,6 +1134,26 @@ export default class DiplomacyBoard {
             changed = true;
           }
         }
+      }
+    }
+
+    // Convoy disruption: a convoyed move only succeeds if a convoy path survives
+    // through fleets that ordered the convoy AND are not themselves dislodged.
+    // _adjudicate's up-front hasConvoyPath check (above) uses all ordered fleets,
+    // so re-check here against the fleets that survive adjudication and fail any
+    // convoyed move whose route is now broken. The army falls back to a hold.
+    const dislodgedLocs = new Set();
+    for (const [loc, unit] of Object.entries(this.units)) {
+      const order = validOrders[loc];
+      if (order?.type === 'move' && moveSuccess[loc]) continue;
+      const attacked = Object.entries(validOrders)
+        .some(([from, attack]) => attack.type === 'move' && attack.to === loc && moveSuccess[from] && this.units[from].power !== unit.power);
+      if (attacked) dislodgedLocs.add(loc);
+    }
+    for (const [loc, order] of Object.entries(validOrders)) {
+      if (order.type !== 'move' || !order.viaConvoy || !moveSuccess[loc]) continue;
+      if (!this._convoyPathSurvives(order.unitLoc, order.to, validOrders, dislodgedLocs)) {
+        moveSuccess[loc] = false;
       }
     }
 

--- a/src/games/diplomacy/DiplomacyBoard.js
+++ b/src/games/diplomacy/DiplomacyBoard.js
@@ -1,0 +1,1342 @@
+// DiplomacyBoard.js
+// Pure rules/state engine for a browser-playable classic Diplomacy implementation.
+
+const POWERS = ['austria', 'england', 'france', 'germany', 'italy', 'russia', 'turkey'];
+
+const POWER_NAMES = {
+  austria: 'Austria-Hungary',
+  england: 'England',
+  france: 'France',
+  germany: 'Germany',
+  italy: 'Italy',
+  russia: 'Russia',
+  turkey: 'Turkey',
+};
+
+const POWER_SHORT_NAMES = {
+  austria: 'Austria',
+  england: 'England',
+  france: 'France',
+  germany: 'Germany',
+  italy: 'Italy',
+  russia: 'Russia',
+  turkey: 'Turkey',
+};
+
+const POWER_COLORS = {
+  austria: '#C2410C',
+  england: '#7C3AED',
+  france: '#2563EB',
+  germany: '#475569',
+  italy: '#16A34A',
+  russia: '#DC2626',
+  turkey: '#D97706',
+};
+
+const POWER_ACCENTS = {
+  austria: '#FED7AA',
+  england: '#DDD6FE',
+  france: '#BFDBFE',
+  germany: '#CBD5E1',
+  italy: '#BBF7D0',
+  russia: '#FECACA',
+  turkey: '#FDE68A',
+};
+
+const HOME_CENTERS = {
+  austria: ['BUD', 'TRI', 'VIE'],
+  england: ['EDI', 'LON', 'LVP'],
+  france: ['BRE', 'MAR', 'PAR'],
+  germany: ['BER', 'KIE', 'MUN'],
+  italy: ['NAP', 'ROM', 'VEN'],
+  russia: ['MOS', 'SEV', 'STP', 'WAR'],
+  turkey: ['ANK', 'CON', 'SMY'],
+};
+
+const INITIAL_UNITS = {
+  austria: [
+    ['army', 'BUD'],
+    ['fleet', 'TRI'],
+    ['army', 'VIE'],
+  ],
+  england: [
+    ['fleet', 'EDI'],
+    ['fleet', 'LON'],
+    ['army', 'LVP'],
+  ],
+  france: [
+    ['fleet', 'BRE'],
+    ['army', 'MAR'],
+    ['army', 'PAR'],
+  ],
+  germany: [
+    ['army', 'BER'],
+    ['fleet', 'KIE'],
+    ['army', 'MUN'],
+  ],
+  italy: [
+    ['fleet', 'NAP'],
+    ['army', 'ROM'],
+    ['army', 'VEN'],
+  ],
+  russia: [
+    ['army', 'MOS'],
+    ['fleet', 'SEV'],
+    ['fleet', 'STP'],
+    ['army', 'WAR'],
+  ],
+  turkey: [
+    ['fleet', 'ANK'],
+    ['army', 'CON'],
+    ['army', 'SMY'],
+  ],
+};
+
+const SEA_PROVINCES = [
+  'ADR', 'AEG', 'BAL', 'BAR', 'BLA', 'BOT', 'EAS', 'ENG', 'GOB', 'GOL',
+  'HEL', 'ION', 'IRI', 'MAO', 'NAO', 'NTH', 'NWG', 'SKA', 'TYS', 'WES',
+];
+
+const PROVINCES = {
+  ADR: { name: 'Adriatic Sea', type: 'sea', x: 627, y: 646 },
+  AEG: { name: 'Aegean Sea', type: 'sea', x: 790, y: 720 },
+  ALB: { name: 'Albania', type: 'coast', x: 670, y: 660 },
+  ANK: { name: 'Ankara', type: 'coast', supply: true, home: 'turkey', x: 928, y: 622 },
+  APU: { name: 'Apulia', type: 'coast', x: 590, y: 693 },
+  ARM: { name: 'Armenia', type: 'coast', x: 980, y: 558 },
+  BAL: { name: 'Baltic Sea', type: 'sea', x: 590, y: 352 },
+  BAR: { name: 'Barents Sea', type: 'sea', x: 548, y: 70 },
+  BEL: { name: 'Belgium', type: 'coast', supply: true, x: 392, y: 470 },
+  BER: { name: 'Berlin', type: 'coast', supply: true, home: 'germany', x: 575, y: 423 },
+  BLA: { name: 'Black Sea', type: 'sea', x: 875, y: 608 },
+  BOH: { name: 'Bohemia', type: 'land', x: 595, y: 548 },
+  BOT: { name: 'Gulf of Bothnia', type: 'sea', x: 640, y: 248 },
+  BRE: { name: 'Brest', type: 'coast', supply: true, home: 'france', x: 255, y: 522 },
+  BUD: { name: 'Budapest', type: 'land', supply: true, home: 'austria', x: 685, y: 565 },
+  BUL: { name: 'Bulgaria', type: 'coast', supply: true, x: 800, y: 638 },
+  BUR: { name: 'Burgundy', type: 'land', x: 430, y: 552 },
+  CLY: { name: 'Clyde', type: 'coast', x: 212, y: 222 },
+  CON: { name: 'Constantinople', type: 'coast', supply: true, home: 'turkey', x: 862, y: 668 },
+  DEN: { name: 'Denmark', type: 'coast', supply: true, x: 505, y: 336 },
+  EAS: { name: 'Eastern Mediterranean', type: 'sea', x: 890, y: 765 },
+  EDI: { name: 'Edinburgh', type: 'coast', supply: true, home: 'england', x: 255, y: 255 },
+  ENG: { name: 'English Channel', type: 'sea', x: 265, y: 432 },
+  FIN: { name: 'Finland', type: 'coast', x: 690, y: 205 },
+  GAL: { name: 'Galicia', type: 'land', x: 720, y: 505 },
+  GAS: { name: 'Gascony', type: 'coast', x: 315, y: 606 },
+  GOB: { name: 'Gulf of Finland', type: 'sea', x: 708, y: 318 },
+  GOL: { name: 'Gulf of Lyon', type: 'sea', x: 407, y: 718 },
+  GRE: { name: 'Greece', type: 'coast', supply: true, x: 722, y: 707 },
+  HEL: { name: 'Helgoland Bight', type: 'sea', x: 430, y: 385 },
+  HOL: { name: 'Holland', type: 'coast', supply: true, x: 438, y: 435 },
+  ION: { name: 'Ionian Sea', type: 'sea', x: 650, y: 760 },
+  IRI: { name: 'Irish Sea', type: 'sea', x: 160, y: 392 },
+  KIE: { name: 'Kiel', type: 'coast', supply: true, home: 'germany', x: 506, y: 415 },
+  LON: { name: 'London', type: 'coast', supply: true, home: 'england', x: 302, y: 382 },
+  LVN: { name: 'Livonia', type: 'coast', x: 735, y: 363 },
+  LVP: { name: 'Liverpool', type: 'coast', supply: true, home: 'england', x: 220, y: 310 },
+  MAO: { name: 'Mid-Atlantic Ocean', type: 'sea', x: 138, y: 610 },
+  MAR: { name: 'Marseilles', type: 'coast', supply: true, home: 'france', x: 380, y: 658 },
+  MOS: { name: 'Moscow', type: 'land', supply: true, home: 'russia', x: 855, y: 392 },
+  MUN: { name: 'Munich', type: 'land', supply: true, home: 'germany', x: 528, y: 550 },
+  NAF: { name: 'North Africa', type: 'coast', x: 350, y: 806 },
+  NAO: { name: 'North Atlantic Ocean', type: 'sea', x: 80, y: 168 },
+  NAP: { name: 'Naples', type: 'coast', supply: true, home: 'italy', x: 542, y: 734 },
+  NWG: { name: 'Norwegian Sea', type: 'sea', x: 230, y: 122 },
+  NTH: { name: 'North Sea', type: 'sea', x: 358, y: 320 },
+  NWY: { name: 'Norway', type: 'coast', supply: true, x: 410, y: 190 },
+  PAR: { name: 'Paris', type: 'land', supply: true, home: 'france', x: 345, y: 555 },
+  PIC: { name: 'Picardy', type: 'coast', x: 340, y: 500 },
+  PIE: { name: 'Piedmont', type: 'coast', x: 438, y: 640 },
+  POR: { name: 'Portugal', type: 'coast', supply: true, x: 162, y: 688 },
+  PRU: { name: 'Prussia', type: 'coast', x: 660, y: 396 },
+  ROM: { name: 'Rome', type: 'coast', supply: true, home: 'italy', x: 478, y: 718 },
+  RUH: { name: 'Ruhr', type: 'land', x: 472, y: 496 },
+  RUM: { name: 'Rumania', type: 'coast', supply: true, x: 782, y: 592 },
+  SER: { name: 'Serbia', type: 'land', supply: true, x: 708, y: 622 },
+  SEV: { name: 'Sevastopol', type: 'coast', supply: true, home: 'russia', x: 912, y: 526 },
+  SIL: { name: 'Silesia', type: 'land', x: 632, y: 496 },
+  SKA: { name: 'Skagerrak', type: 'sea', x: 468, y: 270 },
+  SMY: { name: 'Smyrna', type: 'coast', supply: true, home: 'turkey', x: 908, y: 720 },
+  SPA: { name: 'Spain', type: 'coast', supply: true, x: 270, y: 700 },
+  STP: { name: 'St. Petersburg', type: 'coast', supply: true, home: 'russia', x: 765, y: 155 },
+  SWE: { name: 'Sweden', type: 'coast', supply: true, x: 542, y: 260 },
+  SYR: { name: 'Syria', type: 'coast', x: 980, y: 782 },
+  TRI: { name: 'Trieste', type: 'coast', supply: true, home: 'austria', x: 620, y: 628 },
+  TUN: { name: 'Tunis', type: 'coast', supply: true, x: 505, y: 808 },
+  TUS: { name: 'Tuscany', type: 'coast', x: 462, y: 682 },
+  TYS: { name: 'Tyrrhenian Sea', type: 'sea', x: 520, y: 780 },
+  TYR: { name: 'Tyrolia', type: 'land', x: 552, y: 625 },
+  UKR: { name: 'Ukraine', type: 'land', x: 812, y: 510 },
+  VEN: { name: 'Venice', type: 'coast', supply: true, home: 'italy', x: 520, y: 670 },
+  VIE: { name: 'Vienna', type: 'land', supply: true, home: 'austria', x: 625, y: 560 },
+  WAL: { name: 'Wales', type: 'coast', x: 238, y: 370 },
+  WAR: { name: 'Warsaw', type: 'land', supply: true, home: 'russia', x: 745, y: 455 },
+  WES: { name: 'Western Mediterranean', type: 'sea', x: 305, y: 770 },
+  YOR: { name: 'Yorkshire', type: 'coast', x: 286, y: 318 },
+};
+
+const ARMY_ADJACENCY = {
+  ALB: ['TRI', 'SER', 'GRE'],
+  ANK: ['ARM', 'CON', 'SMY'],
+  APU: ['VEN', 'ROM', 'NAP'],
+  ARM: ['ANK', 'SMY', 'SYR', 'SEV'],
+  BEL: ['HOL', 'RUH', 'BUR', 'PIC'],
+  BER: ['KIE', 'MUN', 'SIL', 'PRU'],
+  BOH: ['MUN', 'SIL', 'GAL', 'VIE', 'TYR'],
+  BRE: ['PIC', 'PAR', 'GAS'],
+  BUD: ['VIE', 'GAL', 'RUM', 'SER', 'TRI'],
+  BUL: ['SER', 'RUM', 'CON', 'GRE'],
+  BUR: ['PAR', 'PIC', 'BEL', 'RUH', 'MUN', 'MAR', 'GAS'],
+  CLY: ['EDI', 'LVP'],
+  CON: ['BUL', 'ANK', 'SMY'],
+  DEN: ['KIE', 'SWE'],
+  EDI: ['CLY', 'LVP', 'YOR'],
+  FIN: ['STP', 'NWY', 'SWE'],
+  GAL: ['WAR', 'UKR', 'RUM', 'BUD', 'VIE', 'BOH', 'SIL'],
+  GAS: ['BRE', 'PAR', 'BUR', 'MAR', 'SPA'],
+  GRE: ['ALB', 'SER', 'BUL'],
+  HOL: ['BEL', 'RUH', 'KIE'],
+  KIE: ['HOL', 'RUH', 'MUN', 'BER', 'DEN'],
+  LON: ['WAL', 'YOR'],
+  LVN: ['STP', 'MOS', 'WAR', 'PRU'],
+  LVP: ['CLY', 'EDI', 'YOR', 'WAL'],
+  MAR: ['SPA', 'GAS', 'BUR', 'PIE'],
+  MOS: ['STP', 'LVN', 'WAR', 'UKR', 'SEV'],
+  MUN: ['RUH', 'KIE', 'BER', 'SIL', 'BOH', 'TYR', 'BUR'],
+  NAF: ['TUN'],
+  NAP: ['ROM', 'APU'],
+  NWY: ['STP', 'FIN', 'SWE'],
+  PAR: ['BRE', 'PIC', 'BUR', 'GAS'],
+  PIC: ['BRE', 'PAR', 'BUR', 'BEL'],
+  PIE: ['MAR', 'TYR', 'TUS', 'VEN'],
+  POR: ['SPA'],
+  PRU: ['BER', 'SIL', 'WAR', 'LVN'],
+  ROM: ['TUS', 'VEN', 'APU', 'NAP'],
+  RUH: ['HOL', 'KIE', 'MUN', 'BUR', 'BEL'],
+  RUM: ['UKR', 'GAL', 'BUD', 'SER', 'BUL', 'SEV'],
+  SER: ['TRI', 'BUD', 'RUM', 'BUL', 'GRE', 'ALB'],
+  SEV: ['MOS', 'UKR', 'RUM', 'ARM'],
+  SIL: ['BER', 'PRU', 'WAR', 'GAL', 'BOH', 'MUN'],
+  SMY: ['CON', 'ANK', 'ARM', 'SYR'],
+  SPA: ['POR', 'GAS', 'MAR'],
+  STP: ['NWY', 'FIN', 'LVN', 'MOS'],
+  SWE: ['NWY', 'FIN', 'DEN'],
+  SYR: ['SMY', 'ARM'],
+  TRI: ['VEN', 'TYR', 'VIE', 'BUD', 'SER', 'ALB'],
+  TUN: ['NAF'],
+  TUS: ['PIE', 'VEN', 'ROM'],
+  TYR: ['MUN', 'BOH', 'VIE', 'TRI', 'VEN', 'PIE'],
+  UKR: ['WAR', 'MOS', 'SEV', 'RUM', 'GAL'],
+  VEN: ['PIE', 'TYR', 'TRI', 'TUS', 'ROM', 'APU'],
+  VIE: ['TYR', 'BOH', 'GAL', 'BUD', 'TRI'],
+  WAL: ['LVP', 'YOR', 'LON'],
+  WAR: ['LVN', 'MOS', 'UKR', 'GAL', 'SIL', 'PRU'],
+  YOR: ['EDI', 'LVP', 'WAL', 'LON'],
+};
+
+const FLEET_ADJACENCY = {
+  ADR: ['VEN', 'TRI', 'ALB', 'ION', 'APU'],
+  AEG: ['GRE', 'BUL', 'CON', 'SMY', 'EAS', 'ION'],
+  ALB: ['TRI', 'ADR', 'ION', 'GRE'],
+  ANK: ['BLA', 'ARM', 'CON'],
+  APU: ['VEN', 'ADR', 'ION', 'NAP'],
+  ARM: ['BLA', 'ANK', 'SEV'],
+  BAL: ['SWE', 'DEN', 'KIE', 'BER', 'PRU', 'LVN', 'BOT', 'GOB'],
+  BAR: ['NWG', 'NWY', 'STP'],
+  BEL: ['ENG', 'NTH', 'HOL', 'PIC'],
+  BER: ['KIE', 'BAL', 'PRU'],
+  BLA: ['BUL', 'RUM', 'SEV', 'ARM', 'ANK', 'CON'],
+  BOT: ['SWE', 'FIN', 'STP', 'LVN', 'BAL', 'GOB'],
+  BRE: ['ENG', 'MAO', 'PIC', 'GAS'],
+  BUL: ['BLA', 'CON', 'RUM', 'AEG', 'GRE'],
+  CLY: ['NAO', 'NWG', 'EDI', 'LVP'],
+  CON: ['BLA', 'ANK', 'SMY', 'AEG', 'BUL'],
+  DEN: ['NTH', 'SKA', 'SWE', 'BAL', 'KIE', 'HEL'],
+  EAS: ['AEG', 'ION', 'SMY', 'SYR'],
+  EDI: ['NWG', 'NTH', 'YOR', 'CLY', 'LVP'],
+  ENG: ['LON', 'WAL', 'BRE', 'PIC', 'BEL', 'NTH', 'IRI', 'MAO'],
+  FIN: ['GOB', 'BOT', 'STP', 'SWE'],
+  GAS: ['MAO', 'BRE', 'SPA'],
+  GOB: ['SWE', 'FIN', 'STP', 'BOT', 'BAL', 'LVN'],
+  GOL: ['SPA', 'MAR', 'PIE', 'TUS', 'TYS', 'WES'],
+  GRE: ['ION', 'AEG', 'ALB', 'BUL'],
+  HEL: ['HOL', 'KIE', 'DEN', 'NTH', 'SKA'],
+  HOL: ['NTH', 'HEL', 'KIE', 'BEL'],
+  ION: ['TYS', 'TUN', 'NAP', 'APU', 'ADR', 'ALB', 'GRE', 'AEG', 'EAS'],
+  IRI: ['NAO', 'MAO', 'ENG', 'WAL', 'LVP'],
+  KIE: ['HEL', 'BAL', 'DEN', 'HOL', 'BER'],
+  LON: ['NTH', 'ENG', 'WAL', 'YOR'],
+  LVN: ['BAL', 'BOT', 'GOB', 'PRU', 'STP'],
+  LVP: ['NAO', 'IRI', 'WAL', 'CLY', 'EDI'],
+  MAO: ['NAO', 'IRI', 'ENG', 'BRE', 'GAS', 'SPA', 'POR', 'WES', 'NAF'],
+  MAR: ['SPA', 'GOL', 'PIE'],
+  NAF: ['MAO', 'WES', 'TUN'],
+  NAO: ['NWG', 'CLY', 'LVP', 'IRI', 'MAO'],
+  NAP: ['TYS', 'ION', 'APU', 'ROM'],
+  NWG: ['NAO', 'CLY', 'EDI', 'NTH', 'NWY', 'BAR'],
+  NTH: ['NWG', 'NWY', 'SKA', 'DEN', 'HEL', 'HOL', 'BEL', 'ENG', 'LON', 'YOR', 'EDI'],
+  NWY: ['NWG', 'NTH', 'SKA', 'SWE', 'BAR', 'STP'],
+  PIC: ['ENG', 'BEL', 'BRE'],
+  PIE: ['MAR', 'GOL', 'TUS'],
+  POR: ['MAO', 'SPA'],
+  PRU: ['BER', 'BAL', 'LVN'],
+  ROM: ['TUS', 'TYS', 'NAP'],
+  RUM: ['BLA', 'BUL', 'SEV'],
+  SEV: ['BLA', 'RUM', 'ARM'],
+  SKA: ['NWY', 'SWE', 'DEN', 'NTH', 'HEL'],
+  SMY: ['CON', 'AEG', 'EAS', 'SYR'],
+  SPA: ['POR', 'GAS', 'MAO', 'WES', 'GOL', 'MAR'],
+  STP: ['BAR', 'NWY', 'FIN', 'GOB', 'BOT', 'LVN'],
+  SWE: ['NWY', 'SKA', 'DEN', 'BAL', 'BOT', 'GOB', 'FIN'],
+  SYR: ['EAS', 'SMY'],
+  TRI: ['VEN', 'ADR', 'ALB'],
+  TUN: ['NAF', 'WES', 'TYS', 'ION'],
+  TUS: ['PIE', 'GOL', 'TYS', 'ROM', 'VEN'],
+  TYS: ['WES', 'GOL', 'TUS', 'ROM', 'NAP', 'TUN', 'ION'],
+  VEN: ['TRI', 'ADR', 'APU', 'TUS'],
+  WAL: ['LVP', 'IRI', 'ENG', 'LON'],
+  WES: ['MAO', 'SPA', 'GOL', 'TYS', 'TUN', 'NAF'],
+  YOR: ['EDI', 'NTH', 'LON'],
+};
+
+const ALL_PROVINCES = Object.keys(PROVINCES).sort();
+const SUPPLY_CENTERS = ALL_PROVINCES.filter(id => PROVINCES[id].supply);
+const SEA_SET = new Set(SEA_PROVINCES);
+
+function uniq(values) {
+  return [...new Set(values)];
+}
+
+function sorted(values) {
+  return [...values].sort((a, b) => a.localeCompare(b));
+}
+
+function cloneOrder(order) {
+  return order ? { ...order } : null;
+}
+
+function orderKey(order) {
+  if (!order) return 'null';
+  switch (order.type) {
+    case 'hold':
+      return `H:${order.unitLoc}`;
+    case 'move':
+      return `M:${order.unitLoc}>${order.to}${order.viaConvoy ? ':C' : ''}`;
+    case 'support-hold':
+      return `SH:${order.unitLoc}:${order.target}`;
+    case 'support-move':
+      return `SM:${order.unitLoc}:${order.from}>${order.to}`;
+    case 'convoy':
+      return `C:${order.unitLoc}:${order.from}>${order.to}`;
+    case 'retreat':
+      return `R:${order.unitLoc}>${order.to || 'DISBAND'}`;
+    case 'build':
+      return `B:${order.power}:${order.unitType}:${order.loc}`;
+    case 'disband':
+      return `D:${order.unitLoc}`;
+    default:
+      return JSON.stringify(order);
+  }
+}
+
+function formatUnitType(type) {
+  return type === 'fleet' ? 'F' : 'A';
+}
+
+function isSea(loc) {
+  return SEA_SET.has(loc);
+}
+
+function isLandOrCoast(loc) {
+  return !!PROVINCES[loc] && !isSea(loc);
+}
+
+function unitCanOccupy(unitType, loc) {
+  if (!PROVINCES[loc]) return false;
+  if (unitType === 'army') return isLandOrCoast(loc);
+  return PROVINCES[loc].type === 'sea' || PROVINCES[loc].type === 'coast';
+}
+
+function adjacencyFor(unitType, loc) {
+  return unitType === 'fleet'
+    ? (FLEET_ADJACENCY[loc] || [])
+    : (ARMY_ADJACENCY[loc] || []);
+}
+
+function emptyCenterOwners() {
+  const owners = {};
+  for (const center of SUPPLY_CENTERS) {
+    owners[center] = PROVINCES[center].home || null;
+  }
+  return owners;
+}
+
+function initialUnits() {
+  const units = {};
+  for (const power of POWERS) {
+    for (const [type, loc] of INITIAL_UNITS[power]) {
+      units[loc] = { power, type };
+    }
+  }
+  return units;
+}
+
+function phaseAfterMovement(season) {
+  return season === 'spring' ? 'fall-orders' : 'winter-build';
+}
+
+export default class DiplomacyBoard {
+  static POWERS = POWERS;
+  static POWER_NAMES = POWER_NAMES;
+  static POWER_SHORT_NAMES = POWER_SHORT_NAMES;
+  static POWER_COLORS = POWER_COLORS;
+  static POWER_ACCENTS = POWER_ACCENTS;
+  static PROVINCES = PROVINCES;
+  static SUPPLY_CENTERS = SUPPLY_CENTERS;
+  static HOME_CENTERS = HOME_CENTERS;
+
+  constructor({ skipInitialHistory = false, maxYears = 1912 } = {}) {
+    this.powers = [...POWERS];
+    this.units = initialUnits();
+    this.supplyCenters = emptyCenterOwners();
+    this.phase = 'spring-orders';
+    this.season = 'spring';
+    this.year = 1901;
+    this.turnNumber = 1;
+    this.maxYears = maxYears;
+    this.winner = null;
+    this.winningCenters = 0;
+    this.lastAction = 'Spring 1901 orders are open.';
+    this.orderHistory = [];
+    this.pendingRetreats = [];
+    this.contestedProvinces = [];
+    this.adjustments = this.getAdjustments();
+    this.stateHistory = [];
+    this.historyIndex = -1;
+    this.maxHistoryLength = 80;
+
+    if (!skipInitialHistory) this._captureState();
+  }
+
+  clone() {
+    return DiplomacyBoard.fromSerializedState(this.serializeState());
+  }
+
+  startNewGame() {
+    const next = new DiplomacyBoard();
+    Object.assign(this, next);
+    this._captureState();
+  }
+
+  getPowerIds() {
+    return this.powers.filter(power => this.getUnitLocations(power).length > 0 || this.getSupplyCount(power) > 0);
+  }
+
+  getProvince(id) {
+    return PROVINCES[id] || null;
+  }
+
+  getUnitLocations(power = null) {
+    return sorted(Object.entries(this.units)
+      .filter(([, unit]) => !power || unit.power === power)
+      .map(([loc]) => loc));
+  }
+
+  getUnits(power = null) {
+    return this.getUnitLocations(power).map(loc => ({ loc, ...this.units[loc] }));
+  }
+
+  getSupplyCenters(power = null) {
+    return sorted(Object.entries(this.supplyCenters)
+      .filter(([, owner]) => !power || owner === power)
+      .map(([loc]) => loc));
+  }
+
+  getSupplyCount(power) {
+    return this.getSupplyCenters(power).length;
+  }
+
+  getScore(power) {
+    return this.getSupplyCount(power);
+  }
+
+  getUnitCount(power) {
+    return this.getUnitLocations(power).length;
+  }
+
+  getLeader() {
+    return this.powers
+      .map(power => ({ power, centers: this.getSupplyCount(power), units: this.getUnitCount(power) }))
+      .sort((a, b) => b.centers - a.centers || b.units - a.units || a.power.localeCompare(b.power))[0];
+  }
+
+  isOrdersPhase() {
+    return this.phase === 'spring-orders' || this.phase === 'fall-orders';
+  }
+
+  isRetreatPhase() {
+    return this.phase === 'spring-retreats' || this.phase === 'fall-retreats';
+  }
+
+  isWinterPhase() {
+    return this.phase === 'winter-build';
+  }
+
+  getPhaseLabel() {
+    if (this.phase === 'game-over') return 'Game over';
+    if (this.isWinterPhase()) return `Winter ${this.year}`;
+    const season = this.season === 'spring' ? 'Spring' : 'Fall';
+    if (this.isRetreatPhase()) return `${season} ${this.year} retreats`;
+    return `${season} ${this.year} orders`;
+  }
+
+  canUnitMove(unitType, from, to, { viaConvoy = false, convoyOrders = null } = {}) {
+    if (!this.units[from] || !PROVINCES[to] || !unitCanOccupy(unitType, to)) return false;
+    if (adjacencyFor(unitType, from).includes(to)) return true;
+    if (unitType === 'army' && viaConvoy) return this.hasConvoyPath(from, to, convoyOrders);
+    return false;
+  }
+
+  canSupport(unitType, supportLoc, targetLoc) {
+    return unitCanOccupy(unitType, targetLoc) && adjacencyFor(unitType, supportLoc).includes(targetLoc);
+  }
+
+  getMoveTargets(loc, { includeConvoys = true } = {}) {
+    const unit = this.units[loc];
+    if (!unit) return [];
+    const direct = adjacencyFor(unit.type, loc).filter(to => unitCanOccupy(unit.type, to));
+    if (unit.type !== 'army' || !includeConvoys) return sorted(direct);
+
+    const convoyTargets = this.getConvoyTargets(loc);
+    return sorted(uniq([...direct, ...convoyTargets]));
+  }
+
+  getConvoyTargets(armyLoc) {
+    const unit = this.units[armyLoc];
+    if (!unit || unit.type !== 'army' || !PROVINCES[armyLoc] || PROVINCES[armyLoc].type !== 'coast') return [];
+    const fleetSeas = Object.entries(this.units)
+      .filter(([, candidate]) => candidate.type === 'fleet')
+      .map(([loc]) => loc)
+      .filter(isSea);
+    if (fleetSeas.length === 0) return [];
+
+    const coastStarts = fleetSeas.filter(sea => FLEET_ADJACENCY[sea]?.includes(armyLoc));
+    if (coastStarts.length === 0) return [];
+
+    const fleetSet = new Set(fleetSeas);
+    const seen = new Set(coastStarts);
+    const queue = [...coastStarts];
+    const reachableSeas = [];
+    while (queue.length) {
+      const sea = queue.shift();
+      reachableSeas.push(sea);
+      for (const next of FLEET_ADJACENCY[sea] || []) {
+        if (!fleetSet.has(next) || seen.has(next)) continue;
+        seen.add(next);
+        queue.push(next);
+      }
+    }
+
+    const targets = [];
+    for (const sea of reachableSeas) {
+      for (const loc of FLEET_ADJACENCY[sea] || []) {
+        if (loc !== armyLoc && isLandOrCoast(loc) && unitCanOccupy('army', loc)) targets.push(loc);
+      }
+    }
+    return sorted(uniq(targets));
+  }
+
+  hasConvoyPath(from, to, ordersByLoc = null) {
+    if (!PROVINCES[from] || !PROVINCES[to] || PROVINCES[from].type !== 'coast' || PROVINCES[to].type !== 'coast') return false;
+    const convoyFleets = Object.entries(this.units)
+      .filter(([loc, unit]) => unit.type === 'fleet' && isSea(loc))
+      .filter(([loc]) => {
+        if (!ordersByLoc) return true;
+        const order = ordersByLoc[loc];
+        return order?.type === 'convoy' && order.from === from && order.to === to;
+      })
+      .map(([loc]) => loc);
+    const fleetSet = new Set(convoyFleets);
+    const starts = convoyFleets.filter(sea => FLEET_ADJACENCY[sea]?.includes(from));
+    if (starts.length === 0) return false;
+    const seen = new Set(starts);
+    const queue = [...starts];
+    while (queue.length) {
+      const sea = queue.shift();
+      if (FLEET_ADJACENCY[sea]?.includes(to)) return true;
+      for (const next of FLEET_ADJACENCY[sea] || []) {
+        if (!fleetSet.has(next) || seen.has(next)) continue;
+        seen.add(next);
+        queue.push(next);
+      }
+    }
+    return false;
+  }
+
+  getLegalOrdersForUnit(loc, { includeSupport = true, includeConvoys = true } = {}) {
+    const unit = this.units[loc];
+    if (!unit) return [];
+    const orders = [{ type: 'hold', unitLoc: loc }];
+    for (const to of this.getMoveTargets(loc, { includeConvoys })) {
+      orders.push({
+        type: 'move',
+        unitLoc: loc,
+        to,
+        viaConvoy: unit.type === 'army' && !adjacencyFor('army', loc).includes(to),
+      });
+    }
+    if (!includeSupport) return orders;
+
+    const adjacentOccupied = sorted(Object.keys(this.units).filter(target => target !== loc && this.canSupport(unit.type, loc, target)));
+    for (const target of adjacentOccupied) {
+      orders.push({ type: 'support-hold', unitLoc: loc, target });
+    }
+
+    const moveOrders = [];
+    for (const [from, movingUnit] of Object.entries(this.units)) {
+      if (from === loc) continue;
+      for (const to of this.getMoveTargets(from, { includeConvoys: false })) {
+        if (to === from || !this.canSupport(unit.type, loc, to)) continue;
+        if (!this.canUnitMove(movingUnit.type, from, to)) continue;
+        moveOrders.push({ type: 'support-move', unitLoc: loc, from, to });
+      }
+    }
+    orders.push(...moveOrders.slice(0, 28));
+
+    if (unit.type === 'fleet' && isSea(loc) && includeConvoys) {
+      for (const [from, movingUnit] of Object.entries(this.units)) {
+        if (movingUnit.type !== 'army' || !FLEET_ADJACENCY[loc]?.includes(from)) continue;
+        for (const to of ALL_PROVINCES) {
+          if (to === from || !isLandOrCoast(to) || !FLEET_ADJACENCY[loc]?.includes(to)) continue;
+          orders.push({ type: 'convoy', unitLoc: loc, from, to });
+        }
+      }
+    }
+
+    return orders;
+  }
+
+  getLegalOrders(power) {
+    return Object.fromEntries(this.getUnitLocations(power).map(loc => [loc, this.getLegalOrdersForUnit(loc)]));
+  }
+
+  getRetreatOptions(unitLoc) {
+    const retreat = this.pendingRetreats.find(entry => entry.unitLoc === unitLoc);
+    return retreat ? [...retreat.options] : [];
+  }
+
+  getAdjustments() {
+    const adjustments = {};
+    for (const power of POWERS) {
+      const centers = this.getSupplyCount(power);
+      const units = this.getUnitCount(power);
+      const delta = centers - units;
+      const openHomes = HOME_CENTERS[power].filter(loc => this.supplyCenters[loc] === power && !this.units[loc]);
+      adjustments[power] = {
+        delta,
+        openHomes,
+        buildCount: Math.max(0, Math.min(delta, openHomes.length)),
+        disbandCount: Math.max(0, -delta),
+      };
+    }
+    return adjustments;
+  }
+
+  getLegalAdjustmentOrders(power) {
+    const adjustment = this.getAdjustments()[power];
+    if (!adjustment) return [];
+    if (adjustment.delta > 0) {
+      const orders = [];
+      for (const loc of adjustment.openHomes) {
+        orders.push({ type: 'build', power, unitType: 'army', loc });
+        if (PROVINCES[loc].type === 'coast') orders.push({ type: 'build', power, unitType: 'fleet', loc });
+      }
+      return orders;
+    }
+    if (adjustment.delta < 0) {
+      return this.getUnitLocations(power).map(unitLoc => ({ type: 'disband', unitLoc }));
+    }
+    return [];
+  }
+
+  getLegalMoves(power, options = {}) {
+    if (this.isOrdersPhase()) return this.generateCandidatePlans(power, options);
+    if (this.isRetreatPhase()) return this.generateRetreatPlans(power);
+    if (this.isWinterPhase()) return this.generateAdjustmentPlans(power);
+    return [];
+  }
+
+  generateCandidatePlans(power, { maxPlans = 48, includeSupport = true } = {}) {
+    const locs = this.getUnitLocations(power);
+    if (locs.length === 0) return [{ type: 'orders-plan', power, orders: [] }];
+    let beam = [{ orders: [], score: 0 }];
+    for (const loc of locs) {
+      const candidates = this.getLegalOrdersForUnit(loc, { includeSupport, includeConvoys: true })
+        .map(order => ({ order, score: this.scoreOrder(order, power) }))
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 10);
+      const nextBeam = [];
+      for (const entry of beam) {
+        for (const candidate of candidates) {
+          const orders = [...entry.orders, candidate.order];
+          nextBeam.push({ orders, score: entry.score + candidate.score + this._planSynergy(orders, power) });
+        }
+      }
+      beam = nextBeam
+        .sort((a, b) => b.score - a.score)
+        .slice(0, Math.max(maxPlans * 2, 16));
+    }
+
+    const seen = new Set();
+    const plans = [];
+    for (const entry of beam.sort((a, b) => b.score - a.score)) {
+      const key = entry.orders.map(orderKey).sort().join('|');
+      if (seen.has(key)) continue;
+      seen.add(key);
+      plans.push({ type: 'orders-plan', power, orders: entry.orders, score: entry.score });
+      if (plans.length >= maxPlans) break;
+    }
+    return plans.length ? plans : [{ type: 'orders-plan', power, orders: locs.map(unitLoc => ({ type: 'hold', unitLoc })) }];
+  }
+
+  generateRetreatPlans(power) {
+    const retreats = this.pendingRetreats.filter(entry => entry.unit.power === power);
+    if (retreats.length === 0) return [{ type: 'retreats-plan', power, retreats: [] }];
+    let plans = [{ retreats: [], score: 0 }];
+    for (const retreat of retreats) {
+      const candidates = [
+        ...retreat.options.map(to => ({ type: 'retreat', unitLoc: retreat.unitLoc, to })),
+        { type: 'retreat', unitLoc: retreat.unitLoc, to: null },
+      ].map(order => ({ order, score: order.to ? this.provinceValue(power, order.to) : -220 }));
+      const next = [];
+      for (const plan of plans) {
+        for (const candidate of candidates) {
+          next.push({ retreats: [...plan.retreats, candidate.order], score: plan.score + candidate.score });
+        }
+      }
+      plans = next.sort((a, b) => b.score - a.score).slice(0, 16);
+    }
+    return plans.map(plan => ({ type: 'retreats-plan', power, retreats: plan.retreats, score: plan.score }));
+  }
+
+  generateAdjustmentPlans(power) {
+    const adjustment = this.getAdjustments()[power];
+    if (!adjustment || adjustment.delta === 0) return [{ type: 'adjustments-plan', power, adjustments: [] }];
+    const legal = this.getLegalAdjustmentOrders(power);
+    if (adjustment.delta > 0) {
+      const byLoc = legal
+        .map(order => ({ order, score: this.provinceValue(power, order.loc) + (order.unitType === 'fleet' ? 18 : 0) }))
+        .sort((a, b) => b.score - a.score);
+      const selected = [];
+      const used = new Set();
+      for (const entry of byLoc) {
+        if (used.has(entry.order.loc)) continue;
+        selected.push(entry.order);
+        used.add(entry.order.loc);
+        if (selected.length >= adjustment.buildCount) break;
+      }
+      return [{ type: 'adjustments-plan', power, adjustments: selected }];
+    }
+    return [{
+      type: 'adjustments-plan',
+      power,
+      adjustments: legal
+        .map(order => ({ order, score: this.provinceValue(power, order.unitLoc) }))
+        .sort((a, b) => a.score - b.score)
+        .slice(0, adjustment.disbandCount)
+        .map(entry => entry.order),
+    }];
+  }
+
+  provinceValue(power, loc) {
+    const province = PROVINCES[loc];
+    if (!province) return 0;
+    let score = province.supply ? 260 : 28;
+    const owner = this.supplyCenters[loc];
+    const occupant = this.units[loc];
+    if (province.supply && owner === power) score += 120;
+    if (province.supply && owner && owner !== power) score += 360 + Math.max(0, this.getSupplyCount(owner) - this.getSupplyCount(power)) * 22;
+    if (province.supply && !owner) score += 300;
+    if (province.home === power) score += 95;
+    if (occupant?.power === power) score += 35;
+    if (occupant && occupant.power !== power) score += 80;
+    const adjacentEnemyCenters = adjacencyFor(province.type === 'sea' ? 'fleet' : 'army', loc)
+      .filter(adj => PROVINCES[adj]?.supply && this.supplyCenters[adj] && this.supplyCenters[adj] !== power).length;
+    score += adjacentEnemyCenters * 35;
+    if (province.type === 'sea') score += (FLEET_ADJACENCY[loc]?.filter(adj => PROVINCES[adj]?.supply).length || 0) * 20;
+    return score;
+  }
+
+  scoreOrder(order, power) {
+    const unit = this.units[order.unitLoc];
+    if (!unit) return -1000;
+    switch (order.type) {
+      case 'hold': {
+        const locValue = this.provinceValue(power, order.unitLoc);
+        const ownsCenter = PROVINCES[order.unitLoc]?.supply && this.supplyCenters[order.unitLoc] === power;
+        return (ownsCenter ? 155 : 18) + locValue * 0.12;
+      }
+      case 'move': {
+        let score = this.provinceValue(power, order.to);
+        if (this.units[order.to]?.power === power) score -= 180;
+        if (this.supplyCenters[order.to] === power && !this.units[order.to]) score += this.season === 'fall' ? 80 : 20;
+        if (PROVINCES[order.to]?.supply && this.supplyCenters[order.to] !== power) score += this.season === 'fall' ? 260 : 140;
+        if (order.viaConvoy) score += 35;
+        return score;
+      }
+      case 'support-hold': {
+        const target = this.units[order.target];
+        if (!target) return -100;
+        return target.power === power
+          ? 190 + this.provinceValue(power, order.target) * 0.3
+          : 60 + this.provinceValue(target.power, order.target) * 0.08;
+      }
+      case 'support-move': {
+        const mover = this.units[order.from];
+        if (!mover) return -100;
+        const friendly = mover.power === power;
+        const targetOwner = this.supplyCenters[order.to];
+        return (friendly ? 230 : 70) + this.provinceValue(power, order.to) * (friendly ? 0.55 : 0.18) + (targetOwner && targetOwner !== power ? 90 : 0);
+      }
+      case 'convoy':
+        return 125 + this.provinceValue(power, order.to) * 0.3;
+      default:
+        return 0;
+    }
+  }
+
+  _planSynergy(orders, power) {
+    let score = 0;
+    const moves = orders.filter(order => order.type === 'move');
+    const supports = orders.filter(order => order.type === 'support-move' || order.type === 'support-hold');
+    const targets = new Map();
+    for (const move of moves) {
+      targets.set(move.to, (targets.get(move.to) || 0) + 1);
+      if (PROVINCES[move.to]?.supply && this.supplyCenters[move.to] !== power) score += 45;
+    }
+    for (const count of targets.values()) {
+      if (count > 1) score -= (count - 1) * 180;
+    }
+    for (const support of supports) {
+      if (support.type === 'support-move' && moves.some(move => move.unitLoc === support.from && move.to === support.to)) score += 140;
+      if (support.type === 'support-hold' && this.units[support.target]?.power === power) score += 75;
+    }
+    return score;
+  }
+
+  applyMove(move) {
+    if (!move || this.phase === 'game-over') return false;
+    if (move.type === 'orders') return this.processOrders(move.ordersByPower || {});
+    if (move.type === 'retreats') return this.processRetreats(move.retreatsByPower || {});
+    if (move.type === 'adjustments') return this.processAdjustments(move.adjustmentsByPower || {});
+    return false;
+  }
+
+  processOrders(ordersByPower) {
+    if (!this.isOrdersPhase()) return false;
+    const ordersByLoc = this._normalizeOrders(ordersByPower);
+    const adjudication = this._adjudicate(ordersByLoc);
+    this.units = adjudication.units;
+    this.pendingRetreats = adjudication.pendingRetreats;
+    this.contestedProvinces = [...adjudication.contestedProvinces];
+    this.orderHistory.unshift({
+      phase: this.getPhaseLabel(),
+      orders: Object.fromEntries(Object.entries(ordersByLoc).map(([loc, order]) => [loc, cloneOrder(order)])),
+      resolved: adjudication.resolved,
+      retreats: this.pendingRetreats.map(entry => ({ ...entry, unit: { ...entry.unit }, options: [...entry.options] })),
+    });
+    this.orderHistory = this.orderHistory.slice(0, 12);
+
+    if (this.pendingRetreats.length > 0) {
+      this.phase = `${this.season}-retreats`;
+      this.lastAction = `${this.pendingRetreats.length} unit${this.pendingRetreats.length === 1 ? '' : 's'} dislodged.`;
+    } else {
+      this._advanceAfterMovement();
+    }
+
+    this._captureState();
+    return true;
+  }
+
+  processRetreats(retreatsByPower) {
+    if (!this.isRetreatPhase()) return false;
+    const byUnit = {};
+    for (const [power, retreats] of Object.entries(retreatsByPower || {})) {
+      for (const retreat of retreats || []) {
+        const pending = this.pendingRetreats.find(entry => entry.unitLoc === retreat.unitLoc && entry.unit.power === power);
+        if (!pending) continue;
+        byUnit[retreat.unitLoc] = { type: 'retreat', unitLoc: retreat.unitLoc, to: retreat.to || null };
+      }
+    }
+
+    const destinationCounts = {};
+    for (const pending of this.pendingRetreats) {
+      const retreat = byUnit[pending.unitLoc] || { type: 'retreat', unitLoc: pending.unitLoc, to: null };
+      if (retreat.to && pending.options.includes(retreat.to)) {
+        destinationCounts[retreat.to] = (destinationCounts[retreat.to] || 0) + 1;
+      }
+    }
+
+    const logs = [];
+    for (const pending of this.pendingRetreats) {
+      const retreat = byUnit[pending.unitLoc] || { type: 'retreat', unitLoc: pending.unitLoc, to: null };
+      if (retreat.to && pending.options.includes(retreat.to) && destinationCounts[retreat.to] === 1 && !this.units[retreat.to]) {
+        this.units[retreat.to] = { ...pending.unit };
+        logs.push(`${formatUnitType(pending.unit.type)} ${pending.unitLoc} retreats to ${retreat.to}`);
+      } else {
+        logs.push(`${formatUnitType(pending.unit.type)} ${pending.unitLoc} disbands`);
+      }
+    }
+
+    if (this.orderHistory[0]) this.orderHistory[0].retreatResolution = logs;
+    this.pendingRetreats = [];
+    this.contestedProvinces = [];
+    this._advanceAfterMovement();
+    this._captureState();
+    return true;
+  }
+
+  processAdjustments(adjustmentsByPower) {
+    if (!this.isWinterPhase()) return false;
+    const legalByPower = this.getAdjustments();
+    const logs = [];
+
+    for (const power of POWERS) {
+      const adjustment = legalByPower[power];
+      const requested = adjustmentsByPower[power] || [];
+      if (adjustment.delta > 0) {
+        const usedHomes = new Set();
+        const builds = [];
+        for (const order of requested) {
+          if (order.type !== 'build' || order.power !== power || usedHomes.has(order.loc)) continue;
+          if (!adjustment.openHomes.includes(order.loc) || this.units[order.loc]) continue;
+          if (!unitCanOccupy(order.unitType, order.loc)) continue;
+          builds.push(order);
+          usedHomes.add(order.loc);
+          if (builds.length >= adjustment.buildCount) break;
+        }
+        for (const order of builds) {
+          this.units[order.loc] = { power, type: order.unitType };
+          logs.push(`${POWER_SHORT_NAMES[power]} builds ${formatUnitType(order.unitType)} ${order.loc}`);
+        }
+      } else if (adjustment.delta < 0) {
+        const needed = adjustment.disbandCount;
+        const disbands = requested
+          .filter(order => order.type === 'disband' && this.units[order.unitLoc]?.power === power)
+          .map(order => order.unitLoc);
+        const fallback = this.getUnitLocations(power)
+          .sort((a, b) => this.provinceValue(power, a) - this.provinceValue(power, b));
+        const selected = [];
+        for (const loc of [...disbands, ...fallback]) {
+          if (selected.includes(loc) || !this.units[loc] || this.units[loc].power !== power) continue;
+          selected.push(loc);
+          if (selected.length >= needed) break;
+        }
+        for (const loc of selected) {
+          delete this.units[loc];
+          logs.push(`${POWER_SHORT_NAMES[power]} disbands ${loc}`);
+        }
+      }
+    }
+
+    this.orderHistory.unshift({ phase: this.getPhaseLabel(), adjustments: logs });
+    this.orderHistory = this.orderHistory.slice(0, 12);
+    this._advanceToNextSpring();
+    this._captureState();
+    return true;
+  }
+
+  _normalizeOrders(ordersByPower) {
+    const byLoc = {};
+    for (const [loc] of Object.entries(this.units)) {
+      byLoc[loc] = { type: 'hold', unitLoc: loc };
+    }
+
+    for (const [power, orders] of Object.entries(ordersByPower || {})) {
+      for (const raw of orders || []) {
+        const loc = raw.unitLoc;
+        const unit = this.units[loc];
+        if (!unit || unit.power !== power) continue;
+        const order = this._sanitizeOrder(raw);
+        byLoc[loc] = order || { type: 'hold', unitLoc: loc };
+      }
+    }
+    return byLoc;
+  }
+
+  _sanitizeOrder(order) {
+    const unit = this.units[order.unitLoc];
+    if (!unit) return null;
+    switch (order.type) {
+      case 'hold':
+        return { type: 'hold', unitLoc: order.unitLoc };
+      case 'move': {
+        const viaConvoy = !!order.viaConvoy || (unit.type === 'army' && !adjacencyFor('army', order.unitLoc).includes(order.to));
+        if (!this.canUnitMove(unit.type, order.unitLoc, order.to, { viaConvoy })) return null;
+        return { type: 'move', unitLoc: order.unitLoc, to: order.to, viaConvoy };
+      }
+      case 'support-hold':
+        if (!this.units[order.target] || !this.canSupport(unit.type, order.unitLoc, order.target)) return null;
+        return { type: 'support-hold', unitLoc: order.unitLoc, target: order.target };
+      case 'support-move': {
+        const mover = this.units[order.from];
+        if (!mover || !this.canSupport(unit.type, order.unitLoc, order.to)) return null;
+        if (!this.canUnitMove(mover.type, order.from, order.to, { viaConvoy: mover.type === 'army' })) return null;
+        return { type: 'support-move', unitLoc: order.unitLoc, from: order.from, to: order.to };
+      }
+      case 'convoy':
+        if (unit.type !== 'fleet' || !isSea(order.unitLoc) || !this.units[order.from] || this.units[order.from].type !== 'army') return null;
+        if (!FLEET_ADJACENCY[order.unitLoc]?.includes(order.from) || !isLandOrCoast(order.to)) return null;
+        return { type: 'convoy', unitLoc: order.unitLoc, from: order.from, to: order.to };
+      default:
+        return null;
+    }
+  }
+
+  _adjudicate(ordersByLoc) {
+    const validOrders = { ...ordersByLoc };
+    for (const [loc, order] of Object.entries(validOrders)) {
+      if (order.type === 'move' && order.viaConvoy && !this.hasConvoyPath(order.unitLoc, order.to, validOrders)) {
+        validOrders[loc] = { type: 'hold', unitLoc: loc, failedConvoy: true };
+      }
+    }
+
+    const attacksByTarget = {};
+    for (const [loc, order] of Object.entries(validOrders)) {
+      if (order.type !== 'move') continue;
+      if (!attacksByTarget[order.to]) attacksByTarget[order.to] = [];
+      attacksByTarget[order.to].push(loc);
+    }
+
+    const cutSupports = new Set();
+    for (const [loc, order] of Object.entries(validOrders)) {
+      if (order.type !== 'support-hold' && order.type !== 'support-move') continue;
+      const attacks = attacksByTarget[loc] || [];
+      for (const attackerLoc of attacks) {
+        const attack = validOrders[attackerLoc];
+        if (!attack) continue;
+        if (order.type === 'support-move' && attackerLoc === order.to) continue;
+        cutSupports.add(loc);
+      }
+    }
+
+    const moveStrength = {};
+    const defenseStrength = {};
+    for (const [loc, unit] of Object.entries(this.units)) {
+      defenseStrength[loc] = 1;
+      if (validOrders[loc]?.type === 'move') moveStrength[loc] = 1;
+    }
+
+    for (const [loc, order] of Object.entries(validOrders)) {
+      if (cutSupports.has(loc)) continue;
+      if (order.type === 'support-hold' && this.units[order.target]) {
+        defenseStrength[order.target] = (defenseStrength[order.target] || 1) + 1;
+      }
+      if (order.type === 'support-move' && this.units[order.from] && validOrders[order.from]?.type === 'move' && validOrders[order.from].to === order.to) {
+        moveStrength[order.from] = (moveStrength[order.from] || 1) + 1;
+      }
+    }
+
+    const moveSuccess = {};
+    const handledHeadToHead = new Set();
+    for (const [loc, order] of Object.entries(validOrders)) {
+      if (order.type !== 'move') continue;
+      moveSuccess[loc] = false;
+    }
+
+    for (const [loc, order] of Object.entries(validOrders)) {
+      if (order.type !== 'move' || handledHeadToHead.has(loc)) continue;
+      const opposing = validOrders[order.to];
+      if (opposing?.type === 'move' && opposing.to === loc && !order.viaConvoy && !opposing.viaConvoy) {
+        handledHeadToHead.add(loc);
+        handledHeadToHead.add(order.to);
+        const aUnit = this.units[loc];
+        const bUnit = this.units[order.to];
+        const a = moveStrength[loc] || 1;
+        const b = moveStrength[order.to] || 1;
+        if (a > b && aUnit.power !== bUnit.power) moveSuccess[loc] = true;
+        if (b > a && bUnit.power !== aUnit.power) moveSuccess[order.to] = true;
+      }
+    }
+
+    let changed = true;
+    let guard = 0;
+    while (changed && guard < 12) {
+      changed = false;
+      guard++;
+      for (const [target, attackers] of Object.entries(attacksByTarget)) {
+        const active = attackers.filter(loc => !handledHeadToHead.has(loc));
+        if (active.length === 0) continue;
+        const ranked = active
+          .map(loc => ({ loc, strength: moveStrength[loc] || 1 }))
+          .sort((a, b) => b.strength - a.strength);
+        const best = ranked[0];
+        if (!best || (ranked[1] && ranked[1].strength === best.strength)) {
+          for (const attacker of active) {
+            if (moveSuccess[attacker] !== false) {
+              moveSuccess[attacker] = false;
+              changed = true;
+            }
+          }
+          continue;
+        }
+
+        const occupant = this.units[target];
+        let succeeds = false;
+        if (!occupant) {
+          succeeds = true;
+        } else {
+          const occupantOrder = validOrders[target];
+          const occupantLeaves = occupantOrder?.type === 'move' && moveSuccess[target] === true;
+          const attackerPower = this.units[best.loc].power;
+          if (occupant.power === attackerPower) {
+            succeeds = occupantLeaves;
+          } else if (occupantLeaves) {
+            succeeds = true;
+          } else {
+            succeeds = best.strength > (defenseStrength[target] || 1);
+          }
+        }
+
+        for (const attacker of active) {
+          const next = attacker === best.loc ? succeeds : false;
+          if (moveSuccess[attacker] !== next) {
+            moveSuccess[attacker] = next;
+            changed = true;
+          }
+        }
+      }
+    }
+
+    const dislodged = [];
+    const newUnits = {};
+    for (const [loc, unit] of Object.entries(this.units)) {
+      const order = validOrders[loc];
+      if (order?.type === 'move' && moveSuccess[loc]) continue;
+      const attackLoc = Object.entries(validOrders)
+        .find(([from, attack]) => attack.type === 'move' && attack.to === loc && moveSuccess[from] && this.units[from].power !== unit.power)?.[0];
+      if (attackLoc) {
+        dislodged.push({ unitLoc: loc, unit: { ...unit }, attackerFrom: attackLoc });
+      } else {
+        newUnits[loc] = { ...unit };
+      }
+    }
+
+    for (const [loc, order] of Object.entries(validOrders)) {
+      if (order.type === 'move' && moveSuccess[loc]) {
+        newUnits[order.to] = { ...this.units[loc] };
+      }
+    }
+
+    const contestedProvinces = sorted(uniq(Object.values(validOrders)
+      .filter(order => order.type === 'move')
+      .map(order => order.to)));
+
+    const pendingRetreats = dislodged
+      .map(entry => {
+        const options = adjacencyFor(entry.unit.type, entry.unitLoc)
+          .filter(to => unitCanOccupy(entry.unit.type, to))
+          .filter(to => !newUnits[to])
+          .filter(to => to !== entry.attackerFrom)
+          .filter(to => !contestedProvinces.includes(to));
+        return { ...entry, options: sorted(options) };
+      })
+      .filter(entry => entry.options.length > 0);
+
+    return {
+      units: newUnits,
+      pendingRetreats,
+      contestedProvinces,
+      resolved: {
+        moveSuccess: { ...moveSuccess },
+        cutSupports: [...cutSupports],
+        dislodged,
+        strengths: { move: moveStrength, defense: defenseStrength },
+      },
+    };
+  }
+
+  _advanceAfterMovement() {
+    if (this.season === 'fall') {
+      this._updateSupplyOwnership();
+      this._checkVictory();
+      if (this.winner) return;
+      this.adjustments = this.getAdjustments();
+      const needsAdjustment = Object.values(this.adjustments).some(entry => entry.buildCount > 0 || entry.disbandCount > 0);
+      if (needsAdjustment) {
+        this.phase = 'winter-build';
+        this.lastAction = `Fall ${this.year} resolved. Winter adjustments are open.`;
+        return;
+      }
+      this._advanceToNextSpring();
+      return;
+    }
+
+    this.season = 'fall';
+    this.phase = phaseAfterMovement('spring');
+    this.lastAction = `Spring ${this.year} resolved. Fall orders are open.`;
+  }
+
+  _advanceToNextSpring() {
+    this.year += 1;
+    this.turnNumber += 1;
+    this.season = 'spring';
+    this.phase = 'spring-orders';
+    this.pendingRetreats = [];
+    this.contestedProvinces = [];
+    this.adjustments = this.getAdjustments();
+    this.lastAction = `Spring ${this.year} orders are open.`;
+    this._checkVictory();
+  }
+
+  _updateSupplyOwnership() {
+    for (const center of SUPPLY_CENTERS) {
+      const unit = this.units[center];
+      if (unit) this.supplyCenters[center] = unit.power;
+    }
+  }
+
+  _checkVictory() {
+    const leader = this.getLeader();
+    if (leader?.centers >= 18) {
+      this.phase = 'game-over';
+      this.winner = leader.power;
+      this.winningCenters = leader.centers;
+      this.lastAction = `${POWER_SHORT_NAMES[leader.power]} controls ${leader.centers} centers.`;
+      return;
+    }
+    if (this.year > this.maxYears) {
+      this.phase = 'game-over';
+      this.winner = leader?.power || null;
+      this.winningCenters = leader?.centers || 0;
+      this.lastAction = `${POWER_SHORT_NAMES[this.winner] || 'No power'} leads after ${this.maxYears - 1900} years.`;
+    }
+  }
+
+  getStateHash() {
+    const units = Object.entries(this.units)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([loc, unit]) => `${loc}:${unit.power[0]}${unit.type[0]}`)
+      .join(',');
+    const centers = Object.entries(this.supplyCenters)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([loc, owner]) => `${loc}:${owner?.[0] || '-'}`)
+      .join(',');
+    return `${this.phase}|${this.year}|${this.season}|${units}|${centers}`;
+  }
+
+  serializeState() {
+    return {
+      powers: [...this.powers],
+      units: Object.fromEntries(Object.entries(this.units).map(([loc, unit]) => [loc, { ...unit }])),
+      supplyCenters: { ...this.supplyCenters },
+      phase: this.phase,
+      season: this.season,
+      year: this.year,
+      turnNumber: this.turnNumber,
+      maxYears: this.maxYears,
+      winner: this.winner,
+      winningCenters: this.winningCenters,
+      lastAction: this.lastAction,
+      orderHistory: this.orderHistory.map(entry => JSON.parse(JSON.stringify(entry))),
+      pendingRetreats: this.pendingRetreats.map(entry => ({
+        ...entry,
+        unit: { ...entry.unit },
+        options: [...entry.options],
+      })),
+      contestedProvinces: [...this.contestedProvinces],
+      adjustments: JSON.parse(JSON.stringify(this.adjustments)),
+      stateHistory: this.stateHistory,
+      historyIndex: this.historyIndex,
+      maxHistoryLength: this.maxHistoryLength,
+    };
+  }
+
+  static fromSerializedState(state) {
+    const board = new DiplomacyBoard({ skipInitialHistory: true, maxYears: state.maxYears || 1912 });
+    board.powers = state.powers ? [...state.powers] : [...POWERS];
+    board.units = Object.fromEntries(Object.entries(state.units || {}).map(([loc, unit]) => [loc, { ...unit }]));
+    board.supplyCenters = { ...emptyCenterOwners(), ...(state.supplyCenters || {}) };
+    board.phase = state.phase || 'spring-orders';
+    board.season = state.season || (board.phase.startsWith('fall') ? 'fall' : 'spring');
+    board.year = state.year || 1901;
+    board.turnNumber = state.turnNumber || 1;
+    board.maxYears = state.maxYears || 1912;
+    board.winner = state.winner || null;
+    board.winningCenters = state.winningCenters || 0;
+    board.lastAction = state.lastAction || '';
+    board.orderHistory = (state.orderHistory || []).map(entry => JSON.parse(JSON.stringify(entry)));
+    board.pendingRetreats = (state.pendingRetreats || []).map(entry => ({
+      ...entry,
+      unit: { ...entry.unit },
+      options: [...entry.options],
+    }));
+    board.contestedProvinces = [...(state.contestedProvinces || [])];
+    board.adjustments = state.adjustments ? JSON.parse(JSON.stringify(state.adjustments)) : board.getAdjustments();
+    board.stateHistory = state.stateHistory || [];
+    board.historyIndex = state.historyIndex ?? -1;
+    board.maxHistoryLength = state.maxHistoryLength || 80;
+    return board;
+  }
+
+  _captureState() {
+    if (this._skipHistory) return;
+    const state = this.serializeState();
+    state.stateHistory = [];
+    state.historyIndex = -1;
+    if (this.historyIndex < this.stateHistory.length - 1) {
+      this.stateHistory = this.stateHistory.slice(0, this.historyIndex + 1);
+    }
+    this.stateHistory.push(JSON.stringify(state));
+    if (this.stateHistory.length > this.maxHistoryLength) this.stateHistory.shift();
+    this.historyIndex = this.stateHistory.length - 1;
+  }
+
+  canUndo() {
+    return this.historyIndex > 0;
+  }
+
+  canRedo() {
+    return this.historyIndex < this.stateHistory.length - 1;
+  }
+
+  undo() {
+    if (!this.canUndo()) return false;
+    this.historyIndex--;
+    this._restoreFromHistory();
+    return true;
+  }
+
+  redo() {
+    if (!this.canRedo()) return false;
+    this.historyIndex++;
+    this._restoreFromHistory();
+    return true;
+  }
+
+  _restoreFromHistory() {
+    const parsed = JSON.parse(this.stateHistory[this.historyIndex]);
+    parsed.stateHistory = this.stateHistory;
+    parsed.historyIndex = this.historyIndex;
+    const restored = DiplomacyBoard.fromSerializedState(parsed);
+    Object.assign(this, restored);
+  }
+}
+
+export {
+  POWERS,
+  POWER_NAMES,
+  POWER_SHORT_NAMES,
+  POWER_COLORS,
+  POWER_ACCENTS,
+  PROVINCES,
+  SUPPLY_CENTERS,
+  HOME_CENTERS,
+  ARMY_ADJACENCY,
+  FLEET_ADJACENCY,
+  SEA_PROVINCES,
+  orderKey,
+  formatUnitType,
+  unitCanOccupy,
+};

--- a/src/games/diplomacy/DiplomacyBoard.test.js
+++ b/src/games/diplomacy/DiplomacyBoard.test.js
@@ -1,0 +1,728 @@
+import DiplomacyBoard, {
+  POWERS,
+  PROVINCES,
+  SUPPLY_CENTERS,
+  HOME_CENTERS,
+  ARMY_ADJACENCY,
+  FLEET_ADJACENCY,
+  unitCanOccupy,
+} from './DiplomacyBoard.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// A bare board with no starting units/centers, parked in a given phase, so that
+// adjudication tests can hand-place exactly the units they care about.
+function emptyBoard({ phase = 'spring-orders', season = 'spring', year = 1901, maxYears = 1912 } = {}) {
+  const board = new DiplomacyBoard({ skipInitialHistory: true, maxYears });
+  board.units = {};
+  board.phase = phase;
+  board.season = season;
+  board.year = year;
+  return board;
+}
+
+function setUnits(board, units) {
+  board.units = {};
+  for (const [loc, spec] of Object.entries(units)) {
+    board.units[loc] = { power: spec.power, type: spec.type };
+  }
+}
+
+// Translate a *-plan object (from getLegalMoves / generate*Plans) into the
+// applyMove envelope. Mirrors the documented shape mismatch in the issue.
+function planToMove(plan, power) {
+  if (plan.type === 'orders-plan') {
+    return { type: 'orders', ordersByPower: { [power]: plan.orders } };
+  }
+  if (plan.type === 'retreats-plan') {
+    return { type: 'retreats', retreatsByPower: { [power]: plan.retreats } };
+  }
+  if (plan.type === 'adjustments-plan') {
+    return { type: 'adjustments', adjustmentsByPower: { [power]: plan.adjustments } };
+  }
+  return null;
+}
+
+// Assert that the board is in a legal positional state: at most one unit per
+// province (the units map keys it that way) and every unit sits where it can.
+function assertLegalState(board) {
+  for (const [loc, unit] of Object.entries(board.units)) {
+    expect(unitCanOccupy(unit.type, loc)).toBe(true);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Data invariants
+// ---------------------------------------------------------------------------
+
+describe('Diplomacy map data invariants', () => {
+  test('army adjacency is symmetric', () => {
+    for (const [from, neighbors] of Object.entries(ARMY_ADJACENCY)) {
+      for (const to of neighbors) {
+        expect(ARMY_ADJACENCY[to]).toBeDefined();
+        expect(ARMY_ADJACENCY[to]).toContain(from);
+      }
+    }
+  });
+
+  test('fleet adjacency is symmetric', () => {
+    for (const [from, neighbors] of Object.entries(FLEET_ADJACENCY)) {
+      for (const to of neighbors) {
+        expect(FLEET_ADJACENCY[to]).toBeDefined();
+        expect(FLEET_ADJACENCY[to]).toContain(from);
+      }
+    }
+  });
+
+  test('every adjacency id exists in PROVINCES with numeric coords', () => {
+    const referenced = new Set();
+    for (const map of [ARMY_ADJACENCY, FLEET_ADJACENCY]) {
+      for (const [from, neighbors] of Object.entries(map)) {
+        referenced.add(from);
+        for (const to of neighbors) referenced.add(to);
+      }
+    }
+    for (const id of referenced) {
+      expect(PROVINCES[id]).toBeDefined();
+    }
+    for (const province of Object.values(PROVINCES)) {
+      expect(typeof province.x).toBe('number');
+      expect(typeof province.y).toBe('number');
+      expect(Number.isFinite(province.x)).toBe(true);
+      expect(Number.isFinite(province.y)).toBe(true);
+    }
+  });
+
+  test('there are exactly 34 supply centers', () => {
+    expect(SUPPLY_CENTERS.length).toBe(34);
+  });
+
+  test('22 home centers across 7 powers, each a supply center owned at start', () => {
+    expect(POWERS.length).toBe(7);
+    const total = POWERS.reduce((sum, power) => sum + HOME_CENTERS[power].length, 0);
+    expect(total).toBe(22);
+
+    const board = new DiplomacyBoard({ skipInitialHistory: true });
+    for (const power of POWERS) {
+      for (const center of HOME_CENTERS[power]) {
+        expect(SUPPLY_CENTERS).toContain(center);
+        expect(PROVINCES[center].supply).toBe(true);
+        expect(board.supplyCenters[center]).toBe(power);
+      }
+    }
+  });
+
+  test('a fresh board has exactly 22 units matching INITIAL_UNITS', () => {
+    const board = new DiplomacyBoard({ skipInitialHistory: true });
+    expect(Object.keys(board.units).length).toBe(22);
+    // Russia has 4, the other six have 3 each => 18 + 4 = 22.
+    expect(board.getUnitCount('russia')).toBe(4);
+    for (const power of POWERS.filter(p => p !== 'russia')) {
+      expect(board.getUnitCount(power)).toBe(3);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adjudication correctness
+// ---------------------------------------------------------------------------
+
+describe('Diplomacy adjudication', () => {
+  test('an unopposed move succeeds', () => {
+    const board = emptyBoard();
+    setUnits(board, { BUD: { power: 'austria', type: 'army' } });
+
+    expect(board.processOrders({ austria: [{ type: 'move', unitLoc: 'BUD', to: 'SER' }] })).toBe(true);
+    expect(board.units.SER).toBeDefined();
+    expect(board.units.SER.power).toBe('austria');
+    expect(board.units.BUD).toBeUndefined();
+  });
+
+  test('two equal-strength moves into the same empty province both bounce', () => {
+    const board = emptyBoard();
+    setUnits(board, {
+      BUD: { power: 'austria', type: 'army' },
+      BUL: { power: 'turkey', type: 'army' },
+    });
+
+    board.processOrders({
+      austria: [{ type: 'move', unitLoc: 'BUD', to: 'SER' }],
+      turkey: [{ type: 'move', unitLoc: 'BUL', to: 'SER' }],
+    });
+
+    expect(board.units.SER).toBeUndefined();
+    expect(board.units.BUD).toBeDefined();
+    expect(board.units.BUL).toBeDefined();
+  });
+
+  test('a support-move dislodges a holding defender', () => {
+    const board = emptyBoard();
+    // BUD -> SER supported by TRI (TRI is army-adjacent to SER).
+    setUnits(board, {
+      BUD: { power: 'austria', type: 'army' },
+      TRI: { power: 'austria', type: 'army' },
+      SER: { power: 'turkey', type: 'army' },
+    });
+
+    board.processOrders({
+      austria: [
+        { type: 'move', unitLoc: 'BUD', to: 'SER' },
+        { type: 'support-move', unitLoc: 'TRI', from: 'BUD', to: 'SER' },
+      ],
+      turkey: [{ type: 'hold', unitLoc: 'SER' }],
+    });
+
+    expect(board.units.SER.power).toBe('austria');
+    // Defender is dislodged and must retreat.
+    expect(board.pendingRetreats.some(r => r.unit.power === 'turkey')).toBe(true);
+  });
+
+  test('a support is cut by an attacker other than the supported-against unit', () => {
+    const board = emptyBoard();
+    // Austria BUD -> SER supported by TRI. Russia ALB attacks TRI (the supporter),
+    // cutting the support. Defender SER then holds 1 vs attack 1 => bounce.
+    setUnits(board, {
+      BUD: { power: 'austria', type: 'army' },
+      TRI: { power: 'austria', type: 'army' },
+      SER: { power: 'turkey', type: 'army' },
+      ALB: { power: 'russia', type: 'army' },
+    });
+
+    board.processOrders({
+      austria: [
+        { type: 'move', unitLoc: 'BUD', to: 'SER' },
+        { type: 'support-move', unitLoc: 'TRI', from: 'BUD', to: 'SER' },
+      ],
+      turkey: [{ type: 'hold', unitLoc: 'SER' }],
+      russia: [{ type: 'move', unitLoc: 'ALB', to: 'TRI' }],
+    });
+
+    // Support cut: BUD's attack is strength 1, SER defends 1, so SER holds.
+    expect(board.units.SER.power).toBe('turkey');
+    expect(board.units.BUD).toBeDefined();
+  });
+
+  test('a support is NOT cut by the unit it is supporting against', () => {
+    const board = emptyBoard();
+    // Austria BUD -> SER, supported by TRI. The defender at SER attacks TRI.
+    // TRI supports a move *into* SER, so an attack from SER must not cut it.
+    setUnits(board, {
+      BUD: { power: 'austria', type: 'army' },
+      TRI: { power: 'austria', type: 'army' },
+      SER: { power: 'turkey', type: 'army' },
+    });
+
+    board.processOrders({
+      austria: [
+        { type: 'move', unitLoc: 'BUD', to: 'SER' },
+        { type: 'support-move', unitLoc: 'TRI', from: 'BUD', to: 'SER' },
+      ],
+      // SER counterattacks the supporter TRI; this attack must not cut the support.
+      turkey: [{ type: 'move', unitLoc: 'SER', to: 'TRI' }],
+    });
+
+    // Support stands: BUD attacks with strength 2 and dislodges SER.
+    expect(board.units.SER.power).toBe('austria');
+    expect(board.pendingRetreats.some(r => r.unit.power === 'turkey')).toBe(true);
+  });
+
+  test('head-to-head with equal strength bounces both units', () => {
+    const board = emptyBoard();
+    setUnits(board, {
+      BUD: { power: 'austria', type: 'army' },
+      GAL: { power: 'russia', type: 'army' },
+    });
+
+    board.processOrders({
+      austria: [{ type: 'move', unitLoc: 'BUD', to: 'GAL' }],
+      russia: [{ type: 'move', unitLoc: 'GAL', to: 'BUD' }],
+    });
+
+    expect(board.units.BUD.power).toBe('austria');
+    expect(board.units.GAL.power).toBe('russia');
+  });
+
+  test('head-to-head with unequal strength dislodges the weaker unit', () => {
+    const board = emptyBoard();
+    setUnits(board, {
+      BUD: { power: 'austria', type: 'army' },
+      VIE: { power: 'austria', type: 'army' },
+      GAL: { power: 'russia', type: 'army' },
+    });
+
+    board.processOrders({
+      austria: [
+        { type: 'move', unitLoc: 'BUD', to: 'GAL' },
+        { type: 'support-move', unitLoc: 'VIE', from: 'BUD', to: 'GAL' },
+      ],
+      russia: [{ type: 'move', unitLoc: 'GAL', to: 'BUD' }],
+    });
+
+    expect(board.units.GAL.power).toBe('austria');
+    expect(board.pendingRetreats.some(r => r.unit.power === 'russia')).toBe(true);
+  });
+
+  test('a convoy succeeds with a valid fleet path', () => {
+    const board = emptyBoard();
+    // Army LON convoyed by fleet NTH to coastal BEL (not army-adjacent to LON).
+    setUnits(board, {
+      LON: { power: 'england', type: 'army' },
+      NTH: { power: 'england', type: 'fleet' },
+    });
+
+    board.processOrders({
+      england: [
+        { type: 'move', unitLoc: 'LON', to: 'BEL', viaConvoy: true },
+        { type: 'convoy', unitLoc: 'NTH', from: 'LON', to: 'BEL' },
+      ],
+    });
+
+    expect(board.units.BEL).toBeDefined();
+    expect(board.units.BEL.power).toBe('england');
+    expect(board.units.LON).toBeUndefined();
+  });
+
+  test('convoy disruption: dislodging the only convoying fleet fails the army move', () => {
+    const board = emptyBoard();
+    // England army LON convoyed by fleet NTH to BEL. France dislodges NTH with a
+    // supported attack (SKA -> NTH supported by HEL). The army must stay home.
+    setUnits(board, {
+      LON: { power: 'england', type: 'army' },
+      NTH: { power: 'england', type: 'fleet' },
+      SKA: { power: 'france', type: 'fleet' },
+      HEL: { power: 'france', type: 'fleet' },
+    });
+
+    board.processOrders({
+      england: [
+        { type: 'move', unitLoc: 'LON', to: 'BEL', viaConvoy: true },
+        { type: 'convoy', unitLoc: 'NTH', from: 'LON', to: 'BEL' },
+      ],
+      france: [
+        { type: 'move', unitLoc: 'SKA', to: 'NTH' },
+        { type: 'support-move', unitLoc: 'HEL', from: 'SKA', to: 'NTH' },
+      ],
+    });
+
+    // The convoying fleet is dislodged, so the army cannot teleport.
+    expect(board.units.BEL).toBeUndefined();
+    expect(board.units.LON).toBeDefined();
+    expect(board.units.LON.power).toBe('england');
+    // The dislodged fleet (England NTH) must retreat.
+    expect(board.pendingRetreats.some(r => r.unit.power === 'england')).toBe(true);
+  });
+
+  test('dislodgement options exclude attacker origin, occupied, and contested provinces', () => {
+    const board = emptyBoard();
+    // Austria BUD -> SER (supported by TRI) dislodges Turkey SER.
+    // SER army neighbors: TRI, BUD, RUM, BUL, GRE, ALB.
+    //  - BUD is the attacker's origin -> excluded.
+    //  - TRI is occupied by the surviving supporter -> excluded.
+    //  - GRE is occupied by a surviving holder -> excluded.
+    //  - BUL is contested (two equal units bounce into it) -> excluded.
+    //  - ALB and RUM stay empty and are valid options.
+    setUnits(board, {
+      BUD: { power: 'austria', type: 'army' },
+      TRI: { power: 'austria', type: 'army' },
+      SER: { power: 'turkey', type: 'army' },
+      GRE: { power: 'turkey', type: 'army' },
+      RUM: { power: 'russia', type: 'army' },
+      CON: { power: 'turkey', type: 'army' },
+    });
+
+    board.processOrders({
+      austria: [
+        { type: 'move', unitLoc: 'BUD', to: 'SER' },
+        { type: 'support-move', unitLoc: 'TRI', from: 'BUD', to: 'SER' },
+      ],
+      turkey: [
+        { type: 'hold', unitLoc: 'SER' },
+        { type: 'hold', unitLoc: 'GRE' },
+        // CON -> BUL bounces against RUM -> BUL, contesting BUL.
+        { type: 'move', unitLoc: 'CON', to: 'BUL' },
+      ],
+      russia: [{ type: 'move', unitLoc: 'RUM', to: 'BUL' }],
+    });
+
+    const retreat = board.pendingRetreats.find(r => r.unitLoc === 'SER');
+    expect(retreat).toBeTruthy();
+    expect(retreat.options).not.toContain('BUD'); // attacker origin
+    expect(retreat.options).not.toContain('TRI'); // occupied (supporter stayed)
+    expect(retreat.options).not.toContain('GRE'); // occupied (holder)
+    expect(retreat.options).not.toContain('BUL'); // contested
+    expect(retreat.options).toContain('ALB'); // valid empty option
+  });
+
+  test('beleaguered garrison: two equal attackers both bounce and the occupant survives', () => {
+    const board = emptyBoard();
+    // SER occupied by Austria (holds). Turkey BUL and Russia RUM both attack SER
+    // with strength 1. They standoff with each other, neither beats the defender.
+    setUnits(board, {
+      SER: { power: 'austria', type: 'army' },
+      BUL: { power: 'turkey', type: 'army' },
+      RUM: { power: 'russia', type: 'army' },
+    });
+
+    board.processOrders({
+      austria: [{ type: 'hold', unitLoc: 'SER' }],
+      turkey: [{ type: 'move', unitLoc: 'BUL', to: 'SER' }],
+      russia: [{ type: 'move', unitLoc: 'RUM', to: 'SER' }],
+    });
+
+    expect(board.units.SER.power).toBe('austria');
+    expect(board.units.BUL).toBeDefined();
+    expect(board.units.RUM).toBeDefined();
+    expect(board.pendingRetreats.length).toBe(0);
+  });
+
+  test('a power cannot dislodge its own unit (no self-dislodgement)', () => {
+    const board = emptyBoard();
+    // Austria BUD -> VIE (supported by TRI) but VIE is Austria's own holding unit.
+    // The move must fail; no self-dislodgement even with superior strength.
+    setUnits(board, {
+      BUD: { power: 'austria', type: 'army' },
+      TRI: { power: 'austria', type: 'army' },
+      VIE: { power: 'austria', type: 'army' },
+    });
+
+    board.processOrders({
+      austria: [
+        { type: 'move', unitLoc: 'BUD', to: 'VIE' },
+        { type: 'support-move', unitLoc: 'TRI', from: 'BUD', to: 'VIE' },
+        { type: 'hold', unitLoc: 'VIE' },
+      ],
+    });
+
+    expect(board.units.VIE.power).toBe('austria');
+    expect(board.units.BUD).toBeDefined(); // attack failed, stays home
+    expect(board.pendingRetreats.length).toBe(0); // own unit never dislodged
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retreats
+// ---------------------------------------------------------------------------
+
+describe('Diplomacy retreats', () => {
+  function dislodgeOneUnit() {
+    // Set up a board where Turkey's SER gets dislodged, leaving a retreat pending.
+    const board = emptyBoard();
+    setUnits(board, {
+      BUD: { power: 'austria', type: 'army' },
+      TRI: { power: 'austria', type: 'army' },
+      SER: { power: 'turkey', type: 'army' },
+    });
+    board.processOrders({
+      austria: [
+        { type: 'move', unitLoc: 'BUD', to: 'SER' },
+        { type: 'support-move', unitLoc: 'TRI', from: 'BUD', to: 'SER' },
+      ],
+      turkey: [{ type: 'hold', unitLoc: 'SER' }],
+    });
+    return board;
+  }
+
+  test('a legal retreat to an empty option succeeds', () => {
+    const board = dislodgeOneUnit();
+    const retreat = board.pendingRetreats.find(r => r.unitLoc === 'SER');
+    expect(retreat).toBeTruthy();
+    const dest = retreat.options[0];
+
+    expect(board.processRetreats({ turkey: [{ type: 'retreat', unitLoc: 'SER', to: dest }] })).toBe(true);
+    expect(board.units[dest]).toBeDefined();
+    expect(board.units[dest].power).toBe('turkey');
+  });
+
+  test('a retreat to a non-option disbands the unit', () => {
+    const board = dislodgeOneUnit();
+    // BUD is the attacker origin and never a legal option; retreating there fails.
+    expect(board.units.SER.power).toBe('austria'); // attacker now occupies SER
+    expect(board.processRetreats({ turkey: [{ type: 'retreat', unitLoc: 'SER', to: 'BUD' }] })).toBe(true);
+    // The dislodged Turkish unit is gone entirely.
+    expect(board.getUnitCount('turkey')).toBe(0);
+  });
+
+  test('two units retreating to the same destination both disband', () => {
+    const board = emptyBoard();
+    // Dislodge two units that share a common empty retreat square.
+    // Austria dislodges Russia GAL (-> options incl. UKR) and Turkey BUL (-> options incl. nothing shared easily).
+    // Simpler: hand-build pendingRetreats with overlapping options.
+    board.phase = 'spring-retreats';
+    board.units = { TRI: { power: 'austria', type: 'army' } };
+    board.pendingRetreats = [
+      { unitLoc: 'BUD', unit: { power: 'russia', type: 'army' }, attackerFrom: 'VIE', options: ['GAL'] },
+      { unitLoc: 'SER', unit: { power: 'turkey', type: 'army' }, attackerFrom: 'ALB', options: ['GAL'] },
+    ];
+
+    expect(board.processRetreats({
+      russia: [{ type: 'retreat', unitLoc: 'BUD', to: 'GAL' }],
+      turkey: [{ type: 'retreat', unitLoc: 'SER', to: 'GAL' }],
+    })).toBe(true);
+
+    // Collision: neither unit survives at GAL.
+    expect(board.units.GAL).toBeUndefined();
+    expect(board.getUnitCount('russia')).toBe(0);
+    expect(board.getUnitCount('turkey')).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Winter builds / disbands
+// ---------------------------------------------------------------------------
+
+describe('Diplomacy winter adjustments', () => {
+  test('a power over its center count disbands down', () => {
+    const board = emptyBoard({ phase: 'winter-build' });
+    // Austria owns 1 center but has 2 units => must disband 1.
+    board.supplyCenters = { BUD: 'austria' };
+    setUnits(board, {
+      BUD: { power: 'austria', type: 'army' },
+      VIE: { power: 'austria', type: 'army' },
+    });
+
+    expect(board.processAdjustments({ austria: [{ type: 'disband', unitLoc: 'VIE' }] })).toBe(true);
+    expect(board.getUnitCount('austria')).toBe(1);
+    expect(board.units.VIE).toBeUndefined();
+  });
+
+  test('a power under its center count builds only on its own empty home centers', () => {
+    const board = emptyBoard({ phase: 'winter-build' });
+    // Austria owns its 3 home centers but has 0 units => may build 3.
+    board.supplyCenters = { BUD: 'austria', TRI: 'austria', VIE: 'austria' };
+    board.units = {};
+
+    // A build on a non-home center (SER) must be ignored; a home build accepted.
+    expect(board.processAdjustments({
+      austria: [
+        { type: 'build', power: 'austria', unitType: 'army', loc: 'SER' }, // not a home -> ignored
+        { type: 'build', power: 'austria', unitType: 'army', loc: 'BUD' }, // home -> accepted
+      ],
+    })).toBe(true);
+
+    expect(board.units.SER).toBeUndefined();
+    expect(board.units.BUD).toBeDefined();
+    expect(board.units.BUD.power).toBe('austria');
+  });
+
+  test('builds are capped by open home centers even with a positive delta', () => {
+    const board = emptyBoard({ phase: 'winter-build' });
+    // Austria owns 3 home centers + SER (4 centers) but only one home is empty:
+    // BUD is occupied by its own army, TRI is occupied, VIE is empty.
+    board.supplyCenters = { BUD: 'austria', TRI: 'austria', VIE: 'austria', SER: 'austria' };
+    setUnits(board, {
+      BUD: { power: 'austria', type: 'army' },
+      TRI: { power: 'austria', type: 'fleet' },
+    });
+    // delta = 4 centers - 2 units = 2, but only VIE is an open home => buildCount 1.
+    const adj = board.getAdjustments().austria;
+    expect(adj.delta).toBe(2);
+    expect(adj.openHomes).toEqual(['VIE']);
+    expect(adj.buildCount).toBe(1);
+
+    expect(board.processAdjustments({
+      austria: [
+        { type: 'build', power: 'austria', unitType: 'army', loc: 'VIE' },
+        { type: 'build', power: 'austria', unitType: 'army', loc: 'BUD' }, // occupied -> ignored
+      ],
+    })).toBe(true);
+
+    expect(board.getUnitCount('austria')).toBe(3); // 2 existing + 1 build
+    expect(board.units.VIE).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Game flow / lifecycle
+// ---------------------------------------------------------------------------
+
+describe('Diplomacy lifecycle', () => {
+  test('supply ownership updates after Fall, not after Spring', () => {
+    // Spring: Austria sits on Turkey-owned SER -- ownership must NOT transfer.
+    const springBoard = emptyBoard({ phase: 'spring-orders', season: 'spring' });
+    springBoard.supplyCenters = { ...springBoard.supplyCenters, SER: 'turkey' };
+    setUnits(springBoard, { SER: { power: 'austria', type: 'army' } });
+    springBoard.processOrders({ austria: [{ type: 'hold', unitLoc: 'SER' }] });
+    expect(springBoard.supplyCenters.SER).toBe('turkey');
+
+    // Fall: same situation -- ownership transfers to Austria.
+    const fallBoard = emptyBoard({ phase: 'fall-orders', season: 'fall' });
+    fallBoard.supplyCenters = { ...fallBoard.supplyCenters, SER: 'turkey' };
+    setUnits(fallBoard, { SER: { power: 'austria', type: 'army' } });
+    fallBoard.processOrders({ austria: [{ type: 'hold', unitLoc: 'SER' }] });
+    expect(fallBoard.supplyCenters.SER).toBe('austria');
+  });
+
+  test('reaching 18 centers ends the game with that power as winner', () => {
+    const board = emptyBoard({ phase: 'fall-orders', season: 'fall' });
+    // Give France 18 centers (it already controls them; a hold confirms ownership).
+    const centers = SUPPLY_CENTERS.slice(0, 18);
+    board.supplyCenters = {};
+    for (const c of centers) board.supplyCenters[c] = 'france';
+    // Place one french unit sitting on one of those centers so a fall resolution runs.
+    setUnits(board, { [centers[0]]: { power: 'france', type: unitCanOccupy('army', centers[0]) ? 'army' : 'fleet' } });
+
+    board.processOrders({ france: [{ type: 'hold', unitLoc: centers[0] }] });
+    expect(board.phase).toBe('game-over');
+    expect(board.winner).toBe('france');
+  });
+
+  test('exceeding maxYears ends the game with the leader as winner', () => {
+    const board = emptyBoard({ phase: 'fall-orders', season: 'fall', year: 1901, maxYears: 1901 });
+    // France leads with 3 centers; nobody reaches 18.
+    board.supplyCenters = { PAR: 'france', BRE: 'france', MAR: 'france', BUD: 'austria' };
+    setUnits(board, {
+      PAR: { power: 'france', type: 'army' },
+      BUD: { power: 'austria', type: 'army' },
+    });
+
+    // Fall 1901 with no builds advances to spring 1902 (> maxYears 1901) => game over.
+    board.processOrders({
+      france: [{ type: 'hold', unitLoc: 'PAR' }],
+      austria: [{ type: 'hold', unitLoc: 'BUD' }],
+    });
+    // Drain any winter phase deterministically.
+    if (board.phase === 'winter-build') board.processAdjustments({});
+
+    expect(board.phase).toBe('game-over');
+    expect(board.winner).toBe('france');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State plumbing
+// ---------------------------------------------------------------------------
+
+describe('Diplomacy state plumbing', () => {
+  test('fromSerializedState(serializeState()) reproduces getStateHash exactly', () => {
+    const board = new DiplomacyBoard({ skipInitialHistory: true });
+    board.processOrders({ austria: [{ type: 'move', unitLoc: 'BUD', to: 'SER' }] });
+    const copy = DiplomacyBoard.fromSerializedState(board.serializeState());
+    expect(copy.getStateHash()).toBe(board.getStateHash());
+  });
+
+  test('clone is independent', () => {
+    const board = new DiplomacyBoard({ skipInitialHistory: true });
+    const clone = board.clone();
+    expect(clone.getStateHash()).toBe(board.getStateHash());
+
+    clone.units.BUD = { power: 'turkey', type: 'fleet' };
+    delete clone.units.VIE;
+    expect(board.units.BUD.power).toBe('austria');
+    expect(board.units.VIE).toBeDefined();
+  });
+
+  test('undo restores the prior hash and redo re-applies it', () => {
+    const board = new DiplomacyBoard(); // keep history for undo/redo
+    const before = board.getStateHash();
+    expect(board.canUndo()).toBe(false);
+
+    board.processOrders({ austria: [{ type: 'move', unitLoc: 'BUD', to: 'SER' }] });
+    const after = board.getStateHash();
+    expect(after).not.toBe(before);
+    expect(board.canUndo()).toBe(true);
+
+    expect(board.undo()).toBe(true);
+    expect(board.getStateHash()).toBe(before);
+    expect(board.canRedo()).toBe(true);
+
+    expect(board.redo()).toBe(true);
+    expect(board.getStateHash()).toBe(after);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AI legality / self-play
+// ---------------------------------------------------------------------------
+
+describe('Diplomacy AI legality', () => {
+  test('orders plans translate into accepted applyMove envelopes', () => {
+    const board = new DiplomacyBoard({ skipInitialHistory: true });
+    expect(board.isOrdersPhase()).toBe(true);
+
+    for (const power of board.getPowerIds()) {
+      const plans = board.getLegalMoves(power);
+      expect(plans.length).toBeGreaterThan(0);
+      for (const plan of plans.slice(0, 3)) {
+        const probe = board.clone();
+        const move = planToMove(plan, power);
+        expect(move).toBeTruthy();
+        expect(probe.applyMove(move)).toBe(true);
+        assertLegalState(probe);
+      }
+    }
+  });
+
+  test('retreats plans translate into accepted applyMove envelopes', () => {
+    // Build a position with a pending retreat, then exercise retreat plans.
+    const board = emptyBoard();
+    setUnits(board, {
+      BUD: { power: 'austria', type: 'army' },
+      TRI: { power: 'austria', type: 'army' },
+      SER: { power: 'turkey', type: 'army' },
+    });
+    board.processOrders({
+      austria: [
+        { type: 'move', unitLoc: 'BUD', to: 'SER' },
+        { type: 'support-move', unitLoc: 'TRI', from: 'BUD', to: 'SER' },
+      ],
+      turkey: [{ type: 'hold', unitLoc: 'SER' }],
+    });
+    expect(board.isRetreatPhase()).toBe(true);
+
+    const plans = board.getLegalMoves('turkey');
+    expect(plans.length).toBeGreaterThan(0);
+    const probe = board.clone();
+    expect(probe.applyMove(planToMove(plans[0], 'turkey'))).toBe(true);
+    assertLegalState(probe);
+  });
+
+  test('adjustments plans translate into accepted applyMove envelopes', () => {
+    const board = emptyBoard({ phase: 'winter-build' });
+    board.supplyCenters = { BUD: 'austria', TRI: 'austria', VIE: 'austria' };
+    board.units = {}; // 3 centers, 0 units => builds available
+    expect(board.isWinterPhase()).toBe(true);
+
+    const plans = board.getLegalMoves('austria');
+    expect(plans.length).toBeGreaterThan(0);
+    const probe = board.clone();
+    expect(probe.applyMove(planToMove(plans[0], 'austria'))).toBe(true);
+    assertLegalState(probe);
+  });
+
+  test('low-budget self-play reaches game-over without illegal moves', () => {
+    // Small maxYears keeps the game short; every applyMove must succeed.
+    const board = new DiplomacyBoard({ maxYears: 1903 });
+    let moves = 0;
+    while (board.phase !== 'game-over' && moves < 200) {
+      if (board.isWinterPhase()) {
+        const adjustmentsByPower = {};
+        for (const power of board.getPowerIds()) {
+          const plan = board.getLegalMoves(power)[0];
+          if (plan) adjustmentsByPower[power] = plan.adjustments;
+        }
+        expect(board.applyMove({ type: 'adjustments', adjustmentsByPower })).toBe(true);
+      } else if (board.isRetreatPhase()) {
+        const retreatsByPower = {};
+        for (const power of board.getPowerIds()) {
+          const plan = board.getLegalMoves(power)[0];
+          if (plan) retreatsByPower[power] = plan.retreats;
+        }
+        expect(board.applyMove({ type: 'retreats', retreatsByPower })).toBe(true);
+      } else {
+        const ordersByPower = {};
+        for (const power of board.getPowerIds()) {
+          const plan = board.getLegalMoves(power)[0];
+          if (plan) ordersByPower[power] = plan.orders;
+        }
+        expect(board.applyMove({ type: 'orders', ordersByPower })).toBe(true);
+      }
+      assertLegalState(board);
+      moves++;
+    }
+
+    expect(board.phase).toBe('game-over');
+    expect(moves).toBeLessThan(200);
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
Commits the previously-untracked pure-logic Diplomacy rules engine (`DiplomacyBoard.js`) and adds a comprehensive Jest contract (`DiplomacyBoard.test.js`) that test-locks it. One real adjudication bug surfaced by the tests is fixed in the engine.

Closes #23

## What's in this PR
1. **Commit** `src/games/diplomacy/DiplomacyBoard.js` (was `?? untracked`).
2. **Author** `src/games/diplomacy/DiplomacyBoard.test.js` — 7 `describe` blocks, 34 `test` cases, mirroring the depth/style of `CatanBoard.test.js`.
3. **Fix** one engine bug the tests caught (convoy disruption).

## Engine fix
- **Convoy disruption.** `_adjudicate` only re-checked `hasConvoyPath` once up front against *ordered* convoys, so a convoyed army still moved even when its only convoying fleet was dislodged during the same turn. Added `_convoyPathSurvives(from, to, validOrders, dislodgedLocs)`, which BFS-checks the route using only fleets that ordered the convoy and were **not** dislodged, and fails the convoyed move (army falls back to a hold) when the path is broken. This is the only behavioral change to the engine; no public method signatures changed.

The other known-fragile areas (support cut by a non-supported-against attacker, support *not* cut by the supported-against unit, head-to-head equal/unequal, beleaguered-garrison standoff, self-dislodgement prohibition, retreat-option exclusions) were probed by tests and found already correct — no change needed.

> caveat: split coasts (STP/SPA/BUL) are deferred to the `[Split Coasts]` sibling issue. Convoy/fleet tests are written against the current single-coast model.

## Validation evidence

### Tests
- `CI=true npm test -- src/games/diplomacy/DiplomacyBoard.test.js` → 34 passed.
- `CI=true npm test` (full suite) → **563 passed, 25 suites** (no regressions in Catan/Chess/Yinsh/Zertz/Splendor).

### Build
- `npm run build` → completes, "The build folder is ready to be deployed."

### File tracking
- `git ls-files src/games/diplomacy/` → `DiplomacyBoard.js`, `DiplomacyBoard.test.js` (exactly the two files; no UI/engine/css).

## Affected areas
- **Files changed:** `src/games/diplomacy/DiplomacyBoard.js` (commit + convoy-disruption fix), `src/games/diplomacy/DiplomacyBoard.test.js` (new).
- **Dependencies:** none.

## Review focus
- The `_convoyPathSurvives` integration in `_adjudicate` (ordering relative to dislodgement and the army's fallback-to-hold).
- Geographic correctness of hand-built test positions (support legality depends on real army/fleet adjacency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)