### PR TITLE
feat(diplomacy): private AI-to-AI negotiation + trust/alliance/betrayal model

### DIFF
--- a/api/diplomacyAgent.js
+++ b/api/diplomacyAgent.js
@@ -49,7 +49,16 @@ function buildSystemPrompt(body = {}) {
   const power = typeof body.power === 'string' ? body.power : '';
   const persona = body.persona && typeof body.persona === 'object' ? body.persona : {};
   const context = body.context && typeof body.context === 'object' ? body.context : {};
-  const addressee = typeof body.addressee === 'string' ? body.addressee : 'the player you are talking to';
+  // `counterparties` (AI↔AI negotiation, [AI Negotiation]) names the rival power(s)
+  // in a private channel; it takes precedence over `addressee` (the human thread).
+  const counterparties = Array.isArray(body.counterparties)
+    ? body.counterparties.filter((p) => typeof p === 'string')
+    : [];
+  const addressee = counterparties.length
+    ? counterparties.map((p) => POWER_NAMES[p] || p).join(' and ')
+    : typeof body.addressee === 'string'
+      ? body.addressee
+      : 'the player you are talking to';
 
   const name = POWER_NAMES[power] || persona.name || 'a Great Power';
   const temperament = persona.temperament && typeof persona.temperament === 'object' ? persona.temperament : {};

--- a/src/games/diplomacy/agents/agentClient.js
+++ b/src/games/diplomacy/agents/agentClient.js
@@ -111,3 +111,56 @@ export async function sendMessage({ power, history, context, addressee, model, s
 
   return result;
 }
+
+// askAgent — the orchestrator-facing call shape used by negotiator.js
+// (runNegotiationPhase). It wraps the same BYO-key endpoint as sendMessage but
+// adds AI↔AI negotiation fields (channel, counterparties) and never writes to any
+// memory store itself — the orchestrator owns transcript/state persistence and
+// keeps AI↔AI text out of the human-visible thread store.
+//   { power, counterparties, channel, boardContext, persona, messages, model }
+// Returns { reply: { message, scratchpad } } on success, or { error, reply }
+// mirroring sendMessage's error contract (no key / network / upstream).
+export async function askAgent({
+  power,
+  counterparties = [],
+  channel,
+  boardContext,
+  persona,
+  messages,
+  model,
+} = {}) {
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    return { error: 'no_key', reply: { message: 'Add your Anthropic API key to enable AI negotiation.' } };
+  }
+
+  const resolvedPersona = persona || getPersona(power);
+  const history = Array.isArray(messages) ? messages : [];
+
+  let res;
+  try {
+    res = await fetch('/api/diplomacyAgent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        apiKey,
+        power,
+        persona: resolvedPersona,
+        context: boardContext,
+        messages: history,
+        counterparties,
+        channel,
+        model,
+      }),
+    });
+  } catch (_) {
+    return { error: 'network', reply: { message: '' } };
+  }
+
+  if (!res.ok) {
+    return { error: 'upstream', reply: { message: '' } };
+  }
+
+  const data = await res.json();
+  return { reply: { message: (data && data.message) || '', scratchpad: (data && data.scratchpad) || null } };
+}

--- a/src/games/diplomacy/agents/betrayalModel.js
+++ b/src/games/diplomacy/agents/betrayalModel.js
@@ -1,0 +1,189 @@
+// Betrayal / decision model for the Diplomacy agents (PR3 of [AI Negotiation]).
+//
+// Given the persisted diplomatic state, decide — per standing agreement — whether
+// the power HONORS or BREAKS it, then assemble the strategic-intent object the
+// [Tactical AI] consumes. Deterministic and pure: no network, no LLM, no React.
+// (The conversational LLM shapes intent indirectly through the trust/deal state
+// that PR2 writes; the actual honor-vs-stab call is made here by cold math so it
+// is testable and reproducible.)
+//
+// Decision rule per agreement involving `power` and `partner`:
+//   honorScore = trust(partner) * W_trust  -  reputationCost(partner) * W_rep
+//   breakScore = payoffGain(breaking)      *  W_payoff
+//   BREAK iff breakScore > honorScore + MARGIN
+//
+// reputationCost(partner) scales with how treacherous the power has already been
+// toward that partner (its broken/kept ledger), weighted by the trust deltas, so
+// a power that has burned a partner before pays less marginal reputation to do it
+// again — but a clean reputation makes the first stab expensive.
+
+import { POWERS } from '../DiplomacyBoard.js';
+import {
+  getTrust,
+  getLedger,
+  getAgreementsFor,
+  agreementPartner,
+} from './diplomaticState.js';
+import { TRUST_DELTAS } from './trustModel.js';
+
+// Named, tunable decision weights (exported for tests + downstream tuning).
+export const W_TRUST = 1.0;   // weight on trusting an ally (favors honoring)
+export const W_REP = 1.0;     // weight on reputational cost of betrayal
+export const W_PAYOFF = 1.0;  // weight on the tactical gain from breaking
+export const MARGIN = 0.15;   // breaking must clear honoring by this much
+
+// Normalizing scale for the raw tactical-payoff proxy (board score units are in
+// the hundreds; this maps a meaningful gain to roughly [0,1]).
+export const PAYOFF_SCALE = 600;
+
+// Reputational cost of betraying `partner`: the trust hit a fresh betrayal lands
+// (|broken delta|), discounted by how reliable this power has been toward the
+// partner so far. A high kept:broken ratio means a betrayal is more shocking
+// (higher cost); a partner already repeatedly betrayed costs little more.
+export function reputationCost(state, power, partner) {
+  const { kept, broken } = getLedger(state, power, partner);
+  const base = Math.abs(TRUST_DELTAS.nonAggressionBroken); // worst-case stab cost
+  const total = kept + broken;
+  if (total === 0) return base; // unblemished record → full reputational stake
+  const reliability = kept / total; // [0,1]
+  return base * reliability;
+}
+
+// Local tactical-payoff proxy: how much standing this power could gain by NOT
+// being bound by its deals — approximated from the best candidate plan's score
+// relative to its current footprint. Returns a value in ~[0,1] after scaling.
+// Callers may inject `payoff` to override (e.g. a real search signal).
+function defaultPayoffGain(board, power) {
+  if (!board || typeof board.generateCandidatePlans !== 'function') return 0;
+  let plans;
+  try {
+    plans = board.generateCandidatePlans(power, { maxPlans: 8 });
+  } catch (_) {
+    return 0;
+  }
+  if (!Array.isArray(plans) || plans.length === 0) return 0;
+  const best = plans.reduce((m, p) => Math.max(m, p.score || 0), 0);
+  return best / PAYOFF_SCALE;
+}
+
+// Threat list from the board: rival powers pressing this power, derived from
+// supply-center standing (the leader and anyone bigger than us is a threat).
+// Used so a power with no agreements still produces sensible targets. Returns
+// powers other than `power` that are alive and at least as large as it.
+function boardThreats(board, power) {
+  if (!board || typeof board.getPowerIds !== 'function') return [];
+  const alive = board.getPowerIds().filter((p) => p !== power);
+  const own = typeof board.getSupplyCount === 'function' ? board.getSupplyCount(power) : 0;
+  const leader = typeof board.getLeader === 'function' ? board.getLeader() : null;
+  const threats = alive.filter((p) => {
+    const c = typeof board.getSupplyCount === 'function' ? board.getSupplyCount(p) : 0;
+    return c >= own;
+  });
+  // Ensure the leader is always considered a threat (even at a tie it's listed).
+  if (leader && leader.power !== power && !threats.includes(leader.power)) {
+    threats.push(leader.power);
+  }
+  return threats.sort();
+}
+
+// decideStrategicIntent({ board, state, power, payoff, seed }) -> strategic intent.
+//
+//   payoff: optional override for the per-power tactical-gain proxy. Either a
+//           number (applied to every agreement) or a function (board, power,
+//           agreement) -> number in ~[0,1]. Defaults to a local proxy via
+//           generateCandidatePlans/scoreOrder. No randomness unless `seed` given
+//           (the decision is deterministic in its inputs regardless).
+export function decideStrategicIntent({ board, state, power, payoff } = {}) {
+  if (!power || typeof power !== 'string') {
+    throw new Error('decideStrategicIntent requires a power');
+  }
+
+  const allies = new Set();
+  const targets = new Set();
+  const supportDeals = [];
+  const dmz = new Set();
+  const betrayals = [];
+  const honoredPartners = new Set();
+  const brokenPartners = new Set();
+
+  const payoffOf = (agreement) => {
+    if (typeof payoff === 'number') return payoff;
+    if (typeof payoff === 'function') return payoff(board, power, agreement);
+    return defaultPayoffGain(board, power);
+  };
+
+  const agreements = state ? getAgreementsFor(state, power) : [];
+
+  for (const agreement of agreements) {
+    const partner = agreementPartner(agreement, power);
+    if (!partner) continue;
+
+    const trust = state ? getTrust(state, power, partner) : 0;
+    const rep = state ? reputationCost(state, power, partner) : 0;
+    const gain = payoffOf(agreement);
+
+    const honorScore = trust * W_TRUST - rep * W_REP;
+    const breakScore = gain * W_PAYOFF;
+    const broken = breakScore > honorScore + MARGIN;
+
+    if (broken) {
+      brokenPartners.add(partner);
+      betrayals.push({ type: agreement.type, partner });
+      targets.add(partner);
+    } else {
+      honoredPartners.add(partner);
+      // Honored deals shape allies / supportDeals / dmz by type.
+      if (agreement.type === 'support') {
+        allies.add(partner);
+        supportDeals.push({ from: agreement.from, to: agreement.to });
+      } else if (agreement.type === 'joint-attack') {
+        allies.add(partner);
+        if (agreement.target) targets.add(agreement.target);
+      } else if (agreement.type === 'non-aggression') {
+        allies.add(partner);
+      } else if (agreement.type === 'dmz') {
+        allies.add(partner);
+        for (const prov of agreement.provinces || []) dmz.add(prov);
+      }
+    }
+  }
+
+  // A partner can be both honored on one deal and betrayed on another; once
+  // betrayed it is a target and must not also be an ally (betrayal dominates).
+  for (const p of brokenPartners) {
+    allies.delete(p);
+    honoredPartners.delete(p);
+  }
+
+  // Honoring a non-aggression / DMZ keeps the partner OUT of targets.
+  for (const p of honoredPartners) targets.delete(p);
+
+  // Add board-derived threats so a power with no (or only honored) agreements
+  // still has someone to press — but never a current ally.
+  for (const t of boardThreats(board, power)) {
+    if (!honoredPartners.has(t)) targets.add(t);
+  }
+
+  return {
+    power,
+    allies: [...allies].sort(),
+    targets: [...targets].sort(),
+    supportDeals,
+    dmz: [...dmz],
+    betrayals,
+  };
+}
+
+// Convenience: decide intents for every alive AI power (POWERS minus the human).
+export function decideAllIntents({ board, state, humanPower, payoff } = {}) {
+  const human = humanPower || (state && state.humanPower) || null;
+  const aiPowers = (board && typeof board.getPowerIds === 'function'
+    ? board.getPowerIds()
+    : POWERS
+  ).filter((p) => p !== human);
+  const intents = {};
+  for (const power of aiPowers) {
+    intents[power] = decideStrategicIntent({ board, state, power, payoff });
+  }
+  return intents;
+}

--- a/src/games/diplomacy/agents/betrayalModel.test.js
+++ b/src/games/diplomacy/agents/betrayalModel.test.js
@@ -1,0 +1,153 @@
+import DiplomacyBoard from '../DiplomacyBoard.js';
+import { createDiplomaticState, recordAgreement } from './diplomaticState.js';
+import { relationKey } from './diplomaticState.js';
+import { validateStrategicIntent } from './strategicIntent.js';
+import {
+  decideStrategicIntent,
+  decideAllIntents,
+  reputationCost,
+  W_TRUST,
+  W_REP,
+  W_PAYOFF,
+  MARGIN,
+} from './betrayalModel.js';
+
+// Set a directional trust value directly on a state (the model only reads it).
+function withTrust(state, from, to, trust) {
+  const next = JSON.parse(JSON.stringify(state));
+  next.relations[relationKey(from, to)] = { trust, lastUpdatedPhase: null };
+  return next;
+}
+
+describe('decideStrategicIntent — schema conformance', () => {
+  test('output validates for every alive AI power on a fresh board', () => {
+    const board = new DiplomacyBoard();
+    const state = createDiplomaticState({ board, humanPower: 'england' });
+    const intents = decideAllIntents({ board, state, humanPower: 'england' });
+    const ai = board.getPowerIds().filter((p) => p !== 'england');
+    expect(Object.keys(intents).sort()).toEqual(ai.sort());
+    for (const power of ai) {
+      expect(validateStrategicIntent(intents[power])).toBe(true);
+      expect(intents[power].power).toBe(power);
+    }
+  });
+
+  test('a power with no agreements yields a valid empty-ish intent with board threats', () => {
+    const board = new DiplomacyBoard();
+    const state = createDiplomaticState({ board, humanPower: 'england' });
+    const intent = decideStrategicIntent({ board, state, power: 'france', payoff: 0 });
+    expect(validateStrategicIntent(intent)).toBe(true);
+    expect(intent.allies).toEqual([]);
+    expect(intent.supportDeals).toEqual([]);
+    expect(intent.betrayals).toEqual([]);
+    expect(intent.dmz).toEqual([]);
+    // Targets are derived from the board even with no deals.
+    expect(intent.targets.length).toBeGreaterThan(0);
+    expect(intent.targets).not.toContain('france');
+  });
+});
+
+describe('decideStrategicIntent — honor vs betray', () => {
+  test('high trust + low payoff → honor (support deal kept, partner not a target)', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    state = recordAgreement(state, { id: 'a1', type: 'support', from: 'france', to: 'germany' });
+    state = withTrust(state, 'france', 'germany', 0.9);
+
+    const intent = decideStrategicIntent({ board, state, power: 'france', payoff: 0.05 });
+    expect(intent.supportDeals).toContainEqual({ from: 'france', to: 'germany' });
+    expect(intent.betrayals).toEqual([]);
+    expect(intent.allies).toContain('germany');
+    expect(intent.targets).not.toContain('germany');
+  });
+
+  test('low trust + high payoff → betray (partner → targets, deal → betrayals)', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    state = recordAgreement(state, { id: 'a1', type: 'non-aggression', parties: ['france', 'germany'] });
+    state = withTrust(state, 'france', 'germany', -0.5);
+
+    const intent = decideStrategicIntent({ board, state, power: 'france', payoff: 1.0 });
+    expect(intent.betrayals).toContainEqual({ type: 'non-aggression', partner: 'germany' });
+    expect(intent.targets).toContain('germany');
+    expect(intent.allies).not.toContain('germany');
+    expect(intent.supportDeals).toEqual([]);
+  });
+
+  test('honored DMZ keeps the partner out of targets and lists its provinces', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    state = recordAgreement(state, {
+      id: 'a1', type: 'dmz', parties: ['france', 'italy'], provinces: ['pie', 'tyr'],
+    });
+    state = withTrust(state, 'france', 'italy', 0.8);
+
+    const intent = decideStrategicIntent({ board, state, power: 'france', payoff: 0.05 });
+    expect(intent.dmz).toEqual(expect.arrayContaining(['pie', 'tyr']));
+    expect(intent.targets).not.toContain('italy');
+    expect(intent.allies).toContain('italy');
+  });
+
+  test('supportDeals (honored) and betrayals are disjoint and partition the support agreements', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    // Two support agreements: one honored (high trust), one betrayed (low trust).
+    state = recordAgreement(state, { id: 'a1', type: 'support', from: 'france', to: 'germany' });
+    state = recordAgreement(state, { id: 'a2', type: 'support', from: 'france', to: 'russia' });
+    state = withTrust(state, 'france', 'germany', 0.9);
+    state = withTrust(state, 'france', 'russia', -0.9);
+
+    const intent = decideStrategicIntent({ board, state, power: 'france', payoff: 0.5 });
+    const honoredPartners = intent.supportDeals.map((d) => d.to);
+    const brokenPartners = intent.betrayals.map((b) => b.partner);
+    expect(honoredPartners).toContain('germany');
+    expect(brokenPartners).toContain('russia');
+    // Disjoint.
+    expect(honoredPartners.filter((p) => brokenPartners.includes(p))).toEqual([]);
+    // Together they cover both support agreements (2).
+    expect(honoredPartners.length + brokenPartners.length).toBe(2);
+  });
+});
+
+describe('decideStrategicIntent — determinism', () => {
+  test('identical inputs produce identical output', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    state = recordAgreement(state, { id: 'a1', type: 'support', from: 'france', to: 'germany' });
+    state = withTrust(state, 'france', 'germany', 0.4);
+    const a = decideStrategicIntent({ board, state, power: 'france', payoff: 0.2 });
+    const b = decideStrategicIntent({ board, state, power: 'france', payoff: 0.2 });
+    expect(a).toEqual(b);
+  });
+
+  test('does not mutate the input state', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    state = recordAgreement(state, { id: 'a1', type: 'support', from: 'france', to: 'germany' });
+    const before = JSON.parse(JSON.stringify(state));
+    decideStrategicIntent({ board, state, power: 'france', payoff: 0.5 });
+    expect(state).toEqual(before);
+  });
+});
+
+describe('reputationCost', () => {
+  test('an unblemished record carries the full reputational stake', () => {
+    const board = new DiplomacyBoard();
+    const state = createDiplomaticState({ board, humanPower: 'england' });
+    expect(reputationCost(state, 'france', 'germany')).toBeCloseTo(0.5, 5);
+  });
+
+  test('a record of broken promises lowers the marginal cost of another betrayal', () => {
+    const board = new DiplomacyBoard();
+    const state = createDiplomaticState({ board, humanPower: 'england' });
+    state.promiseLedger[relationKey('france', 'germany')] = { kept: 1, broken: 3 };
+    // reliability = 1/4 = 0.25 → cost = 0.5 * 0.25 = 0.125
+    expect(reputationCost(state, 'france', 'germany')).toBeCloseTo(0.125, 5);
+  });
+});
+
+describe('exported weights', () => {
+  test('all decision weights are numbers', () => {
+    [W_TRUST, W_REP, W_PAYOFF, MARGIN].forEach((w) => expect(typeof w).toBe('number'));
+  });
+});

--- a/src/games/diplomacy/agents/diplomaticState.js
+++ b/src/games/diplomacy/agents/diplomaticState.js
@@ -1,0 +1,172 @@
+// Per-power diplomatic state for the Diplomacy agents (PR1 of [AI Negotiation]).
+//
+// This is the persisted, cross-turn memory of WHO trusts whom, WHAT deals stand,
+// and WHICH promises were kept or broken. It is the foundation the negotiation
+// orchestrator (PR2) writes into and the betrayal model (PR3) reads from.
+//
+// Pure logic only: no React, no network, no localStorage, no cross-game imports.
+// Every mutator returns a NEW state object and never mutates its input, so the
+// state can live in React state / be serialized alongside the board without the
+// usual clone-or-bust footguns.
+//
+// Schema (version 1 — load-bearing contract, see issue #28):
+//   {
+//     version: 1,
+//     humanPower: 'england',
+//     relations:  { 'france>germany': { trust: 0.42, lastUpdatedPhase: 'Fall 1902' } },
+//     agreements: [ { id, type, ... } ],          // standing, durable deals
+//     promises:   [ { id, type, from, to, expectedOrder, madePhase, actingPower } ],
+//     promiseLedger: { 'france>germany': { kept: 3, broken: 1 } }
+//   }
+//
+// `relations` holds one entry for EVERY ordered pair of alive powers (so both
+// 'france>germany' and 'germany>france' exist) seeded at trust 0. The pair key
+// is directional: 'A>B' is A's trust toward B.
+
+import { POWERS } from '../DiplomacyBoard.js';
+
+export const STATE_VERSION = 1;
+
+// Directional relation key: A's trust toward B.
+export function relationKey(from, to) {
+  return `${from}>${to}`;
+}
+
+// Build the seed state for a new game. Seeds a relations entry for every ordered
+// pair of ALIVE powers (board.getPowerIds()) at trust 0, with empty agreements,
+// promises, and ledger. `humanPower` is validated against POWERS.
+export function createDiplomaticState({ board, humanPower } = {}) {
+  if (!board || typeof board.getPowerIds !== 'function') {
+    throw new Error('createDiplomaticState requires a board with getPowerIds()');
+  }
+  if (humanPower != null && !POWERS.includes(humanPower)) {
+    throw new Error(`createDiplomaticState: humanPower '${humanPower}' is not a valid power`);
+  }
+
+  const alive = board.getPowerIds();
+  const relations = {};
+  for (const from of alive) {
+    for (const to of alive) {
+      if (from === to) continue;
+      relations[relationKey(from, to)] = { trust: 0, lastUpdatedPhase: null };
+    }
+  }
+
+  return {
+    version: STATE_VERSION,
+    humanPower: humanPower || null,
+    relations,
+    agreements: [],
+    promises: [],
+    promiseLedger: {},
+  };
+}
+
+// --- pure helpers -----------------------------------------------------------
+
+// Deep-clone via structured JSON. The state is plain JSON by construction, so
+// this is a faithful, decoupled copy with no shared references to the input.
+function cloneState(state) {
+  return JSON.parse(JSON.stringify(state));
+}
+
+let promiseSeq = 0;
+let agreementSeq = 0;
+
+// Stable-ish unique id. Tests pass an explicit id where determinism matters; the
+// counter only fills the gap for ad-hoc callers.
+function nextId(prefix) {
+  const seq = prefix === 'p' ? ++promiseSeq : ++agreementSeq;
+  return `${prefix}${seq}`;
+}
+
+// --- mutators (return NEW state) --------------------------------------------
+
+// Record a promise made during negotiation. A promise is a SPECIFIC, verifiable
+// commitment to issue a particular order next turn (e.g. support germany's
+// mun->ruh). It carries the acting power explicitly because orderHistory units
+// are mutated and do not store power — trust diffing keys off `actingPower`.
+//
+// promise = { type, from, to, expectedOrder, madePhase, actingPower, id? }
+//   - type: 'support' (the only verifiable promise type today)
+//   - from/to: the directional pair the promise is between
+//   - expectedOrder: the order `actingPower` is expected to issue (order shape)
+//   - actingPower: the power that must issue `expectedOrder` (usually `from`)
+export function recordPromise(state, promise = {}) {
+  const next = cloneState(state);
+  const actingPower = promise.actingPower || promise.from || null;
+  next.promises.push({
+    id: promise.id || nextId('p'),
+    type: promise.type || 'support',
+    from: promise.from || null,
+    to: promise.to || null,
+    expectedOrder: promise.expectedOrder ? { ...promise.expectedOrder } : null,
+    madePhase: promise.madePhase || null,
+    actingPower,
+  });
+  return next;
+}
+
+// Record (or replace) a standing agreement: a durable, typed deal that persists
+// until dropped or violated. Types: 'support' | 'dmz' | 'non-aggression' |
+// 'joint-attack'. Shape varies by type; we store it verbatim plus an id.
+//   - support:        { from, to }
+//   - dmz:            { parties:[a,b], provinces:[...] }
+//   - non-aggression: { parties:[a,b] }
+//   - joint-attack:   { parties:[a,b], target }
+// If an agreement with the same id exists it is replaced (idempotent upsert).
+export function recordAgreement(state, agreement = {}) {
+  const next = cloneState(state);
+  const id = agreement.id || nextId('a');
+  const entry = { ...agreement, id };
+  const idx = next.agreements.findIndex((a) => a.id === id);
+  if (idx >= 0) next.agreements[idx] = entry;
+  else next.agreements.push(entry);
+  return next;
+}
+
+// Remove a standing agreement by id. Returns new state (no-op if absent).
+export function dropAgreement(state, id) {
+  const next = cloneState(state);
+  next.agreements = next.agreements.filter((a) => a.id !== id);
+  return next;
+}
+
+// --- getters (read-only, never mutate) --------------------------------------
+
+// A's trust toward B in [-1,1]; 0 if the pair has no relation entry.
+export function getTrust(state, from, to) {
+  const rel = state.relations[relationKey(from, to)];
+  return rel ? rel.trust : 0;
+}
+
+// Ledger {kept,broken} for A toward B; zeros if none recorded yet.
+export function getLedger(state, from, to) {
+  return state.promiseLedger[relationKey(from, to)] || { kept: 0, broken: 0 };
+}
+
+// All standing agreements that involve `power` (as a party / from / to).
+export function getAgreementsFor(state, power) {
+  return state.agreements.filter((a) => agreementInvolves(a, power));
+}
+
+// All recorded (not-yet-verified) promises whose acting power is `power`.
+export function getPromisesBy(state, power) {
+  return state.promises.filter((p) => p.actingPower === power);
+}
+
+// True if an agreement involves `power` (handles both `parties` and from/to).
+export function agreementInvolves(agreement, power) {
+  if (Array.isArray(agreement.parties)) return agreement.parties.includes(power);
+  return agreement.from === power || agreement.to === power;
+}
+
+// The other party of a two-party agreement relative to `power` (null if none).
+export function agreementPartner(agreement, power) {
+  if (Array.isArray(agreement.parties)) {
+    return agreement.parties.find((p) => p !== power) || null;
+  }
+  if (agreement.from === power) return agreement.to;
+  if (agreement.to === power) return agreement.from;
+  return null;
+}

--- a/src/games/diplomacy/agents/diplomaticState.test.js
+++ b/src/games/diplomacy/agents/diplomaticState.test.js
@@ -1,0 +1,166 @@
+import DiplomacyBoard, { POWERS } from '../DiplomacyBoard.js';
+import {
+  createDiplomaticState,
+  recordPromise,
+  recordAgreement,
+  dropAgreement,
+  relationKey,
+  getTrust,
+  getLedger,
+  getAgreementsFor,
+  getPromisesBy,
+  agreementInvolves,
+  agreementPartner,
+  STATE_VERSION,
+} from './diplomaticState.js';
+
+describe('createDiplomaticState', () => {
+  test('seeds a relation entry for every ordered pair of alive powers at trust 0', () => {
+    const board = new DiplomacyBoard();
+    const state = createDiplomaticState({ board, humanPower: 'england' });
+
+    const alive = board.getPowerIds();
+    const expectedPairs = alive.length * (alive.length - 1);
+    expect(Object.keys(state.relations)).toHaveLength(expectedPairs);
+
+    for (const from of alive) {
+      for (const to of alive) {
+        if (from === to) continue;
+        const rel = state.relations[relationKey(from, to)];
+        expect(rel).toEqual({ trust: 0, lastUpdatedPhase: null });
+      }
+    }
+    // No self-relation.
+    expect(state.relations['france>france']).toBeUndefined();
+  });
+
+  test('starts with empty agreements, promises, and ledger; version stamped', () => {
+    const board = new DiplomacyBoard();
+    const state = createDiplomaticState({ board, humanPower: 'france' });
+    expect(state).toMatchObject({
+      version: STATE_VERSION,
+      humanPower: 'france',
+      agreements: [],
+      promises: [],
+      promiseLedger: {},
+    });
+  });
+
+  test('humanPower must be a valid POWERS member', () => {
+    const board = new DiplomacyBoard();
+    expect(() => createDiplomaticState({ board, humanPower: 'atlantis' })).toThrow();
+    // null is allowed (all-AI game).
+    const state = createDiplomaticState({ board, humanPower: null });
+    expect(state.humanPower).toBeNull();
+    expect(POWERS).toContain('france');
+  });
+
+  test('throws without a board', () => {
+    expect(() => createDiplomaticState({ humanPower: 'france' })).toThrow();
+  });
+});
+
+describe('recordPromise', () => {
+  const board = new DiplomacyBoard();
+  const base = createDiplomaticState({ board, humanPower: 'england' });
+
+  test('appends a promise with the acting power defaulted to `from`', () => {
+    const next = recordPromise(base, {
+      id: 'p1',
+      type: 'support',
+      from: 'france',
+      to: 'germany',
+      expectedOrder: { type: 'support-move', unitLoc: 'bur', from: 'mun', to: 'ruh' },
+      madePhase: 'Spring 1902',
+    });
+    expect(next.promises).toHaveLength(1);
+    expect(next.promises[0]).toMatchObject({
+      id: 'p1',
+      from: 'france',
+      to: 'germany',
+      actingPower: 'france',
+    });
+  });
+
+  test('is pure — does not mutate the input state', () => {
+    const before = JSON.parse(JSON.stringify(base));
+    recordPromise(base, { from: 'france', to: 'italy', type: 'support' });
+    expect(base).toEqual(before);
+    expect(base.promises).toHaveLength(0);
+  });
+
+  test('honors an explicit actingPower distinct from `from`', () => {
+    const next = recordPromise(base, { from: 'france', to: 'germany', actingPower: 'germany' });
+    expect(next.promises[0].actingPower).toBe('germany');
+  });
+});
+
+describe('recordAgreement / dropAgreement', () => {
+  const board = new DiplomacyBoard();
+  const base = createDiplomaticState({ board, humanPower: 'england' });
+
+  test('adds a typed agreement and is retrievable by party', () => {
+    const next = recordAgreement(base, {
+      id: 'a2',
+      type: 'dmz',
+      parties: ['france', 'italy'],
+      provinces: ['pie', 'tyr'],
+    });
+    expect(next.agreements).toHaveLength(1);
+    expect(getAgreementsFor(next, 'france')).toHaveLength(1);
+    expect(getAgreementsFor(next, 'germany')).toHaveLength(0);
+  });
+
+  test('upserts by id (idempotent)', () => {
+    let s = recordAgreement(base, { id: 'a1', type: 'non-aggression', parties: ['france', 'germany'] });
+    s = recordAgreement(s, { id: 'a1', type: 'non-aggression', parties: ['france', 'germany'], note: 'renewed' });
+    expect(s.agreements).toHaveLength(1);
+    expect(s.agreements[0].note).toBe('renewed');
+  });
+
+  test('dropAgreement removes by id and is pure', () => {
+    const withAgr = recordAgreement(base, { id: 'a9', type: 'support', from: 'france', to: 'germany' });
+    const dropped = dropAgreement(withAgr, 'a9');
+    expect(dropped.agreements).toHaveLength(0);
+    expect(withAgr.agreements).toHaveLength(1); // input unchanged
+  });
+
+  test('is pure — input not mutated', () => {
+    const before = JSON.parse(JSON.stringify(base));
+    recordAgreement(base, { type: 'joint-attack', parties: ['france', 'germany'], target: 'italy' });
+    expect(base).toEqual(before);
+  });
+});
+
+describe('getters', () => {
+  const board = new DiplomacyBoard();
+  let state = createDiplomaticState({ board, humanPower: 'england' });
+
+  test('getTrust returns 0 for an unseeded pair and the stored value otherwise', () => {
+    expect(getTrust(state, 'france', 'germany')).toBe(0);
+    expect(getTrust(state, 'nobody', 'someone')).toBe(0);
+  });
+
+  test('getLedger returns zeros when nothing recorded', () => {
+    expect(getLedger(state, 'france', 'germany')).toEqual({ kept: 0, broken: 0 });
+  });
+
+  test('getPromisesBy filters by acting power', () => {
+    state = recordPromise(state, { from: 'france', to: 'germany', actingPower: 'france' });
+    state = recordPromise(state, { from: 'italy', to: 'austria', actingPower: 'italy' });
+    expect(getPromisesBy(state, 'france')).toHaveLength(1);
+    expect(getPromisesBy(state, 'italy')).toHaveLength(1);
+    expect(getPromisesBy(state, 'turkey')).toHaveLength(0);
+  });
+
+  test('agreementInvolves / agreementPartner handle both parties and from/to shapes', () => {
+    const dmz = { type: 'dmz', parties: ['france', 'italy'], provinces: ['pie'] };
+    const support = { type: 'support', from: 'france', to: 'germany' };
+    expect(agreementInvolves(dmz, 'italy')).toBe(true);
+    expect(agreementInvolves(dmz, 'germany')).toBe(false);
+    expect(agreementPartner(dmz, 'france')).toBe('italy');
+    expect(agreementPartner(support, 'france')).toBe('germany');
+    expect(agreementPartner(support, 'germany')).toBe('france');
+    expect(agreementPartner(support, 'italy')).toBeNull();
+  });
+});

--- a/src/games/diplomacy/agents/negotiator.js
+++ b/src/games/diplomacy/agents/negotiator.js
@@ -1,0 +1,361 @@
+// Negotiation orchestrator for the Diplomacy agents (PR2 of [AI Negotiation]).
+//
+// Each negotiation phase, this runs a bounded number of PRIVATE pairwise
+// conversations among the AI powers (and conducts each AI's side of its thread
+// with the human), extracts any concrete deals into the diplomatic state, and
+// returns the AI↔AI transcripts keyed by channel — SEPARATE from the
+// human-visible thread store, which it never touches with AI↔AI text.
+//
+// Runs client-side, off the render path (it is async and pure of React). The LLM
+// call is injected as `askAgent` so tests can mock it (no real key in CI); in the
+// app this is the reused agent endpoint via agentClient.js. Pair selection is
+// deterministic given a seed, and the number of AI↔AI calls is hard-capped at
+// maxRounds × maxPairsPerRound.
+
+import {
+  POWERS,
+  PROVINCES,
+  ARMY_ADJACENCY,
+  FLEET_ADJACENCY,
+  baseProvince,
+} from '../DiplomacyBoard.js';
+import { recordPromise, recordAgreement, getTrust } from './diplomaticState.js';
+
+// --- deterministic RNG (mulberry32) -----------------------------------------
+// Seeded so pair selection / tie-breaking is reproducible across runs.
+function makeRng(seed) {
+  let a = (typeof seed === 'number' ? seed : hashString(String(seed ?? 0))) >>> 0;
+  return function rng() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashString(s) {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+// --- geography --------------------------------------------------------------
+
+// Base provinces a power's units occupy this turn.
+function occupiedBases(board, power) {
+  const set = new Set();
+  for (const { loc } of board.getUnits(power)) set.add(baseProvince(loc));
+  return set;
+}
+
+// All base provinces reachable in one step from `base` by either unit type.
+function neighborsOf(base) {
+  const out = new Set();
+  for (const adj of ARMY_ADJACENCY[base] || []) out.add(baseProvince(adj));
+  for (const adj of FLEET_ADJACENCY[base] || []) out.add(baseProvince(adj));
+  return out;
+}
+
+// True if two powers are geographic neighbors: a province one occupies is
+// adjacent to (or shared with) a province the other occupies.
+function areNeighbors(board, a, b) {
+  const aBases = occupiedBases(board, a);
+  const bBases = occupiedBases(board, b);
+  for (const base of aBases) {
+    if (bBases.has(base)) return true;
+    for (const n of neighborsOf(base)) if (bBases.has(n)) return true;
+  }
+  return false;
+}
+
+// Contested supply centers near a pair (centers either could press): a province
+// that is a supply center and adjacent to BOTH powers' footprints.
+function contestedCentersBetween(board, a, b) {
+  const aReach = reach(board, a);
+  const bReach = reach(board, b);
+  let count = 0;
+  for (const base of aReach) {
+    if (PROVINCES[base]?.supply && bReach.has(base)) count++;
+  }
+  return count;
+}
+
+function reach(board, power) {
+  const out = new Set();
+  for (const base of occupiedBases(board, power)) {
+    out.add(base);
+    for (const n of neighborsOf(base)) out.add(n);
+  }
+  return out;
+}
+
+// --- pair selection ---------------------------------------------------------
+
+// Score a candidate AI↔AI pair. Higher = more worth talking. Priorities:
+//   (a) geographic neighbors, (b) high tension (low trust + contested centers),
+//   (c) allies maintaining deals (some positive trust). Deterministic.
+function scorePair(board, state, a, b) {
+  let score = 0;
+  if (areNeighbors(board, a, b)) score += 100;
+  const contested = contestedCentersBetween(board, a, b);
+  score += contested * 25;
+  const trustAB = getTrust(state, a, b);
+  const trustBA = getTrust(state, b, a);
+  const avgTrust = (trustAB + trustBA) / 2;
+  // Low trust between neighbors = high tension worth negotiating.
+  score += (1 - avgTrust) * 30;
+  // Allies with standing deals get a smaller maintenance bump.
+  const hasDeal = state.agreements.some(
+    (ag) => agreementBetween(ag, a, b)
+  );
+  if (hasDeal && avgTrust > 0) score += 20;
+  return score;
+}
+
+function agreementBetween(agreement, a, b) {
+  if (Array.isArray(agreement.parties)) {
+    return agreement.parties.includes(a) && agreement.parties.includes(b);
+  }
+  return (
+    (agreement.from === a && agreement.to === b) ||
+    (agreement.from === b && agreement.to === a)
+  );
+}
+
+// Pick up to `limit` distinct AI↔AI pairs, highest score first, deterministic
+// given the seed (rng only breaks exact ties). Dead powers excluded by caller.
+function selectPairs(board, state, aiPowers, limit, rng) {
+  const pairs = [];
+  for (let i = 0; i < aiPowers.length; i++) {
+    for (let j = i + 1; j < aiPowers.length; j++) {
+      const a = aiPowers[i];
+      const b = aiPowers[j];
+      pairs.push({ a, b, score: scorePair(board, state, a, b), jitter: rng() });
+    }
+  }
+  pairs.sort((x, y) => y.score - x.score || x.jitter - y.jitter || keyOf(x).localeCompare(keyOf(y)));
+  return pairs.slice(0, limit);
+}
+
+function keyOf(pair) {
+  return `${pair.a}|${pair.b}`;
+}
+
+// --- deal extraction --------------------------------------------------------
+
+// Parse a structured deal proposal from an agent reply. Only a constrained,
+// explicit `deal` field is honored — free text never auto-creates an agreement
+// (prompt-injection mitigation). Returns a normalized deal or null.
+//
+// Accepted deal shapes (mirroring the diplomatic-state agreement/promise types):
+//   { type:'support', from, to, expectedOrder, durable? }   -> promise
+//   { type:'dmz', parties:[a,b], provinces:[...] }           -> agreement
+//   { type:'non-aggression', parties:[a,b] }                 -> agreement
+//   { type:'joint-attack', parties:[a,b], target }           -> agreement
+function extractDeal(reply) {
+  if (!reply || typeof reply !== 'object') return null;
+  const deal = reply.deal;
+  if (!deal || typeof deal !== 'object' || Array.isArray(deal)) return null;
+  if (typeof deal.type !== 'string') return null;
+  return deal;
+}
+
+// Apply an extracted deal to the state, returning the new state. Support deals
+// become promises (verifiable next turn) tagged with the acting power; the rest
+// become standing agreements. `accepted` powers are the channel participants, so
+// a deal is only recorded when the counterparty did not reject it.
+function applyDeal(state, deal, { phase }) {
+  if (deal.type === 'support') {
+    if (!deal.from || !deal.to) return state;
+    return recordPromise(state, {
+      type: 'support',
+      from: deal.from,
+      to: deal.to,
+      actingPower: deal.actingPower || deal.from,
+      expectedOrder: deal.expectedOrder || null,
+      madePhase: phase,
+      durable: !!deal.durable,
+    });
+  }
+  if (deal.type === 'dmz') {
+    if (!Array.isArray(deal.parties) || !Array.isArray(deal.provinces)) return state;
+    return recordAgreement(state, {
+      type: 'dmz',
+      parties: deal.parties,
+      provinces: deal.provinces,
+      phase,
+    });
+  }
+  if (deal.type === 'non-aggression') {
+    if (!Array.isArray(deal.parties)) return state;
+    return recordAgreement(state, { type: 'non-aggression', parties: deal.parties, phase });
+  }
+  if (deal.type === 'joint-attack') {
+    if (!Array.isArray(deal.parties) || !deal.target) return state;
+    return recordAgreement(state, {
+      type: 'joint-attack',
+      parties: deal.parties,
+      target: deal.target,
+      phase,
+    });
+  }
+  return state;
+}
+
+// True if a reply from the counterparty rejects the proposal (so no deal lands).
+function isAccepted(reply) {
+  if (!reply || typeof reply !== 'object') return false;
+  // Explicit rejection wins; otherwise an echoed `deal` counts as acceptance.
+  if (reply.accept === false) return false;
+  return reply.accept === true || !!reply.deal;
+}
+
+// --- channel ids ------------------------------------------------------------
+
+// Stable channel id for an AI↔AI pair (sorted so it's order-independent).
+function channelId(a, b) {
+  return [a, b].sort().join('~');
+}
+
+// --- orchestrator -----------------------------------------------------------
+
+const DEFAULT_OPTIONS = { maxRounds: 2, maxPairsPerRound: 4, humanPower: null, seed: 0 };
+
+// runNegotiationPhase({ board, state, agents, askAgent, options }) -> { state, transcripts }
+//
+//   board:    live DiplomacyBoard (read-only here).
+//   state:    diplomatic state (PR1). Never mutated; a new state is returned.
+//   agents:   optional per-power agent context { [power]: { persona, memory, scratchpad } }.
+//             `agents.humanThreads` (if present) is the HUMAN-VISIBLE thread store
+//             and is NEVER written with AI↔AI text.
+//   askAgent: async ({ power, counterparties, channel, boardContext, persona,
+//             memory, scratchpad, messages }) -> { reply, scratchpadDelta? }.
+//             Injected so tests mock it; the app passes the reused endpoint client.
+//   options:  { maxRounds, maxPairsPerRound, humanPower, seed }.
+//
+// Budget (hard): ≤ maxRounds × maxPairsPerRound AI↔AI askAgent calls, plus ≤ 1
+// askAgent call per AI power for its human-thread turn. Dead powers (not in
+// board.getPowerIds()) are never selected.
+export async function runNegotiationPhase({ board, state, agents = {}, askAgent, options = {} } = {}) {
+  if (!board || typeof board.getPowerIds !== 'function') {
+    throw new Error('runNegotiationPhase requires a board');
+  }
+  if (typeof askAgent !== 'function') {
+    throw new Error('runNegotiationPhase requires an askAgent function');
+  }
+
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+  const human = opts.humanPower || (state && state.humanPower) || null;
+  const phase = typeof board.getPhaseLabel === 'function' ? board.getPhaseLabel() : null;
+
+  const alive = board.getPowerIds();
+  const aiPowers = alive.filter((p) => p !== human);
+
+  const rng = makeRng(opts.seed);
+  // AI↔AI transcripts: { [channelId]: [{ round, power, counterparty, message }] }.
+  const transcripts = {};
+  let nextState = state;
+
+  // 1) AI↔AI rounds (private; never written to the human thread store).
+  for (let round = 0; round < opts.maxRounds; round++) {
+    const pairs = selectPairs(board, nextState, aiPowers, opts.maxPairsPerRound, rng);
+    for (const { a, b } of pairs) {
+      const channel = channelId(a, b);
+      if (!transcripts[channel]) transcripts[channel] = [];
+
+      // Proposer speaks first, then the counterparty replies (one askAgent call
+      // each — but both count toward the AI↔AI budget, so we make a SINGLE call
+      // representing the pair's exchange to honor ≤ maxRounds×maxPairsPerRound).
+      const aCtx = agents[a] || {};
+      const proposal = await askAgent({
+        power: a,
+        counterparties: [b],
+        channel,
+        round,
+        phase,
+        boardContext: aCtx.boardContext || null,
+        persona: aCtx.persona || null,
+        memory: aCtx.memory || null,
+        scratchpad: aCtx.scratchpad || null,
+        messages: transcriptMessages(transcripts[channel], a),
+      });
+
+      const proposalReply = proposal && proposal.reply ? proposal.reply : proposal;
+      transcripts[channel].push({
+        round,
+        power: a,
+        counterparty: b,
+        message: messageText(proposalReply),
+      });
+
+      // Record any concrete, structured deal the proposer offered AND the
+      // counterparty implicitly/explicitly accepted (acceptance is the proposer
+      // emitting a `deal` field; a separate reject reply would clear it).
+      const deal = extractDeal(proposalReply);
+      if (deal && isAccepted(proposalReply)) {
+        nextState = applyDeal(nextState, deal, { phase });
+      }
+    }
+  }
+
+  // 2) Each AI's side of its human↔AI thread: at most ONE call per AI power.
+  //    These replies ARE allowed in the human-visible store (they're addressed
+  //    to the human); AI↔AI transcripts above never are.
+  const humanThreads = agents.humanThreads || null;
+  if (human) {
+    for (const power of aiPowers) {
+      const ctx = agents[power] || {};
+      // Only engage powers that have an open human thread to answer.
+      const thread = humanThreads && humanThreads.threads ? humanThreads.threads[power] : null;
+      if (!thread || !Array.isArray(thread.messages) || thread.messages.length === 0) continue;
+      // Skip if the last message is already from the AI (nothing to answer).
+      if (thread.messages[thread.messages.length - 1].role === 'assistant') continue;
+
+      const res = await askAgent({
+        power,
+        counterparties: [human],
+        channel: `human~${power}`,
+        phase,
+        boardContext: ctx.boardContext || null,
+        persona: ctx.persona || null,
+        memory: ctx.memory || null,
+        scratchpad: ctx.scratchpad || null,
+        messages: thread.messages,
+      });
+      const reply = res && res.reply ? res.reply : res;
+      const text = messageText(reply);
+      if (text && humanThreads) {
+        thread.messages.push({ role: 'assistant', content: text, turn: phase || '' });
+        thread.updatedAt = Date.now();
+      }
+    }
+  }
+
+  return { state: nextState, transcripts };
+}
+
+// Render prior channel transcript into a messages array from `power`'s POV:
+// its own lines are 'assistant', the counterparty's are 'user'.
+function transcriptMessages(entries, power) {
+  return entries.map((e) => ({
+    role: e.power === power ? 'assistant' : 'user',
+    content: e.message,
+  }));
+}
+
+// Pull the visible message text out of an agent reply (string or { message }).
+function messageText(reply) {
+  if (typeof reply === 'string') return reply;
+  if (reply && typeof reply.message === 'string') return reply.message;
+  return '';
+}
+
+// Exported for tests / downstream tools.
+export { channelId, selectPairs, extractDeal };
+
+// Keep POWERS reachable for callers that derive AI powers without a board.
+export { POWERS };

--- a/src/games/diplomacy/agents/negotiator.test.js
+++ b/src/games/diplomacy/agents/negotiator.test.js
@@ -1,0 +1,218 @@
+import DiplomacyBoard from '../DiplomacyBoard.js';
+import { createDiplomaticState } from './diplomaticState.js';
+import { createMemory } from './memory.js';
+import { runNegotiationPhase, selectPairs } from './negotiator.js';
+
+// A call-counting mock askAgent. By default every power stays silent (no deal).
+// Tests override `replyFor(power, ctx)` to script specific proposals.
+function mockAskAgent(replyFor = () => ({ message: '' })) {
+  const calls = [];
+  const fn = async (ctx) => {
+    calls.push(ctx);
+    return { reply: replyFor(ctx.power, ctx) };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// AI↔AI calls have a counterparties list of AI powers (not the human channel).
+function aiToAiCalls(askAgent, human) {
+  return askAgent.calls.filter(
+    (c) => Array.isArray(c.counterparties) && !c.channel.startsWith('human~') && !c.counterparties.includes(human)
+  );
+}
+
+function freshGame(humanPower = 'england') {
+  const board = new DiplomacyBoard();
+  const state = createDiplomaticState({ board, humanPower });
+  return { board, state, humanPower };
+}
+
+describe('runNegotiationPhase — budget', () => {
+  test('AI↔AI calls never exceed maxRounds × maxPairsPerRound', async () => {
+    const { board, state, humanPower } = freshGame();
+    const askAgent = mockAskAgent();
+    await runNegotiationPhase({
+      board, state, askAgent,
+      options: { maxRounds: 2, maxPairsPerRound: 4, humanPower, seed: 7 },
+    });
+    expect(aiToAiCalls(askAgent, humanPower).length).toBeLessThanOrEqual(2 * 4);
+    expect(aiToAiCalls(askAgent, humanPower).length).toBe(8); // 6 AI powers → ≥4 pairs available
+  });
+
+  test('budget scales with R × N', async () => {
+    const { board, state, humanPower } = freshGame();
+    const askAgent = mockAskAgent();
+    await runNegotiationPhase({
+      board, state, askAgent,
+      options: { maxRounds: 3, maxPairsPerRound: 2, humanPower, seed: 1 },
+    });
+    expect(aiToAiCalls(askAgent, humanPower).length).toBeLessThanOrEqual(3 * 2);
+    expect(aiToAiCalls(askAgent, humanPower).length).toBe(6);
+  });
+
+  test('at most one human-thread call per AI power', async () => {
+    const { board, state, humanPower } = freshGame();
+    const aiPowers = board.getPowerIds().filter((p) => p !== humanPower);
+    // Open a human thread for every AI power so each is eligible for a reply.
+    const humanThreads = createMemory(aiPowers);
+    aiPowers.forEach((p) => humanThreads.threads[p].messages.push({ role: 'user', content: 'hello' }));
+
+    const askAgent = mockAskAgent(() => ({ message: 'In time, perhaps.' }));
+    await runNegotiationPhase({
+      board, state, askAgent,
+      agents: { humanThreads },
+      options: { maxRounds: 1, maxPairsPerRound: 4, humanPower, seed: 2 },
+    });
+    const humanCalls = askAgent.calls.filter((c) => c.channel.startsWith('human~'));
+    expect(humanCalls.length).toBe(aiPowers.length);
+    // No AI power gets two human-thread calls.
+    const counts = {};
+    humanCalls.forEach((c) => { counts[c.power] = (counts[c.power] || 0) + 1; });
+    Object.values(counts).forEach((n) => expect(n).toBe(1));
+  });
+});
+
+describe('runNegotiationPhase — determinism', () => {
+  test('pair selection with a fixed seed is deterministic', async () => {
+    const { board, state, humanPower } = freshGame();
+    const a = mockAskAgent();
+    const b = mockAskAgent();
+    const opts = { maxRounds: 2, maxPairsPerRound: 4, humanPower, seed: 42 };
+    await runNegotiationPhase({ board, state, askAgent: a, options: opts });
+    await runNegotiationPhase({ board, state, askAgent: b, options: opts });
+    const chanA = a.calls.map((c) => c.channel);
+    const chanB = b.calls.map((c) => c.channel);
+    expect(chanA).toEqual(chanB);
+  });
+
+  test('selectPairs is a pure deterministic helper', () => {
+    const { board, state } = freshGame();
+    const ai = board.getPowerIds().filter((p) => p !== 'england');
+    const makeRng = () => { let i = 0; return () => (i++ % 7) / 7; };
+    const first = selectPairs(board, state, ai, 4, makeRng());
+    const second = selectPairs(board, state, ai, 4, makeRng());
+    expect(first.map((p) => `${p.a}|${p.b}`)).toEqual(second.map((p) => `${p.a}|${p.b}`));
+  });
+});
+
+describe('runNegotiationPhase — deal extraction', () => {
+  test('a proposed support deal is recorded as a promise with the acting power', async () => {
+    const { board, state, humanPower } = freshGame();
+    const askAgent = mockAskAgent((power, ctx) => {
+      // Only the very first proposer offers a support deal toward its counterparty.
+      if (askAgent.calls.length === 1) {
+        return {
+          message: 'I will back you into the channel.',
+          deal: {
+            type: 'support',
+            from: power,
+            to: ctx.counterparties[0],
+            expectedOrder: { type: 'support-move', unitLoc: 'bur', from: 'mun', to: 'ruh' },
+          },
+        };
+      }
+      return { message: '' };
+    });
+
+    const { state: next } = await runNegotiationPhase({
+      board, state, askAgent,
+      options: { maxRounds: 1, maxPairsPerRound: 4, humanPower, seed: 5 },
+    });
+    expect(next.promises.length).toBe(1);
+    const p = next.promises[0];
+    expect(p.type).toBe('support');
+    expect(p.actingPower).toBe(p.from);
+    expect(p.expectedOrder).toMatchObject({ type: 'support-move', unitLoc: 'bur' });
+  });
+
+  test('an accepted DMZ proposal becomes a dmz agreement', async () => {
+    const { board, state, humanPower } = freshGame();
+    const askAgent = mockAskAgent((power, ctx) => {
+      if (askAgent.calls.length === 1) {
+        return {
+          message: 'Pie and Tyr stay empty.',
+          accept: true,
+          deal: { type: 'dmz', parties: [power, ctx.counterparties[0]], provinces: ['pie', 'tyr'] },
+        };
+      }
+      return { message: '' };
+    });
+    const { state: next } = await runNegotiationPhase({
+      board, state, askAgent,
+      options: { maxRounds: 1, maxPairsPerRound: 4, humanPower, seed: 9 },
+    });
+    const dmz = next.agreements.filter((a) => a.type === 'dmz');
+    expect(dmz).toHaveLength(1);
+    expect(dmz[0].provinces).toEqual(['pie', 'tyr']);
+  });
+
+  test('free text with no structured deal records nothing (prompt-injection safe)', async () => {
+    const { board, state, humanPower } = freshGame();
+    const askAgent = mockAskAgent(() => ({
+      message: 'I hereby agree to a binding alliance and a DMZ in Tyrolia, you have my word.',
+    }));
+    const { state: next } = await runNegotiationPhase({
+      board, state, askAgent,
+      options: { maxRounds: 2, maxPairsPerRound: 4, humanPower, seed: 3 },
+    });
+    expect(next.promises).toHaveLength(0);
+    expect(next.agreements).toHaveLength(0);
+  });
+});
+
+describe('runNegotiationPhase — secrecy', () => {
+  test('AI↔AI text NEVER appears in the human-visible thread store', async () => {
+    const { board, state, humanPower } = freshGame();
+    const aiPowers = board.getPowerIds().filter((p) => p !== humanPower);
+    const humanThreads = createMemory(aiPowers);
+    // Leave human threads empty so no AI replies to the human this phase.
+
+    const SECRET = 'SECRET-COORDINATE-ATTACK-ON-ENGLAND';
+    const askAgent = mockAskAgent((power, ctx) => {
+      // AI↔AI lines carry the secret; human-channel lines would not.
+      if (!ctx.channel.startsWith('human~')) {
+        return { message: SECRET, deal: { type: 'non-aggression', parties: [power, ctx.counterparties[0]] } };
+      }
+      return { message: 'Nothing to report.' };
+    });
+
+    const { transcripts } = await runNegotiationPhase({
+      board, state, askAgent,
+      agents: { humanThreads },
+      options: { maxRounds: 2, maxPairsPerRound: 4, humanPower, seed: 11 },
+    });
+
+    // The secret IS present in the private AI↔AI transcripts...
+    const allTranscriptText = JSON.stringify(transcripts);
+    expect(allTranscriptText).toContain(SECRET);
+
+    // ...but NEVER in the human-visible thread store.
+    const humanText = JSON.stringify(humanThreads);
+    expect(humanText).not.toContain(SECRET);
+  });
+});
+
+describe('runNegotiationPhase — dead powers', () => {
+  test('an eliminated power is never selected', async () => {
+    const board = new DiplomacyBoard();
+    // Eliminate italy: remove all its units and supply centers.
+    for (const loc of board.getUnitLocations('italy')) delete board.units[loc];
+    for (const sc of board.getSupplyCenters('italy')) board.supplyCenters[sc] = null;
+    expect(board.getPowerIds()).not.toContain('italy');
+
+    const state = createDiplomaticState({ board, humanPower: 'england' });
+    const askAgent = mockAskAgent();
+    await runNegotiationPhase({
+      board, state, askAgent,
+      options: { maxRounds: 2, maxPairsPerRound: 6, humanPower: 'england', seed: 4 },
+    });
+    const touched = new Set();
+    askAgent.calls.forEach((c) => {
+      touched.add(c.power);
+      (c.counterparties || []).forEach((p) => touched.add(p));
+    });
+    expect(touched.has('italy')).toBe(false);
+    expect(touched.has('england')).toBe(false); // human never an AI↔AI participant
+  });
+});

--- a/src/games/diplomacy/agents/strategicIntent.js
+++ b/src/games/diplomacy/agents/strategicIntent.js
@@ -1,0 +1,63 @@
+// Strategic-intent schema for the Diplomacy agents (PR3 of [AI Negotiation]).
+//
+// This is the EXACT contract the [Intent Binding] / [Tactical AI] issues consume:
+// the betrayal/decision model (betrayalModel.js) emits one of these per AI power
+// each turn, and the tactical layer binds it to actual orders. Keeping the schema
+// + validator here lets downstream code assert against it without importing the
+// decision model.
+//
+// Pure: no React, no network, no LLM, no cross-game imports.
+//
+//   {
+//     power: 'france',                                   // the deciding power
+//     allies:  ['germany'],                              // powers to cooperate with
+//     targets: ['italy'],                                // powers to press / attack
+//     supportDeals: [ { from: 'france', to: 'germany' } ], // support deals being honored
+//     dmz: ['pie', 'tyr'],                               // provinces left demilitarized
+//     betrayals: [ { type: 'non-aggression', partner: 'germany' } ] // deals being broken
+//   }
+
+const INTENT_KEYS = ['power', 'allies', 'targets', 'supportDeals', 'dmz', 'betrayals'];
+
+// Exported schema description (shape-level; the validator below enforces it).
+export const STRATEGIC_INTENT_SCHEMA = {
+  power: 'string (power id)',
+  allies: 'string[] (power ids)',
+  targets: 'string[] (power ids)',
+  supportDeals: '{ from: string, to: string }[]',
+  dmz: 'string[] (province ids)',
+  betrayals: '{ type: string, partner: string }[]',
+};
+
+function isStringArray(v) {
+  return Array.isArray(v) && v.every((x) => typeof x === 'string');
+}
+
+// True iff `obj` is a well-formed strategic-intent object. Never throws.
+export function validateStrategicIntent(obj) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
+
+  // No stray keys: keeps the contract tight so [Intent Binding] can rely on it.
+  for (const key of Object.keys(obj)) {
+    if (!INTENT_KEYS.includes(key)) return false;
+  }
+
+  if (typeof obj.power !== 'string' || !obj.power) return false;
+  if (!isStringArray(obj.allies)) return false;
+  if (!isStringArray(obj.targets)) return false;
+  if (!isStringArray(obj.dmz)) return false;
+
+  if (!Array.isArray(obj.supportDeals)) return false;
+  for (const d of obj.supportDeals) {
+    if (!d || typeof d !== 'object' || Array.isArray(d)) return false;
+    if (typeof d.from !== 'string' || typeof d.to !== 'string') return false;
+  }
+
+  if (!Array.isArray(obj.betrayals)) return false;
+  for (const b of obj.betrayals) {
+    if (!b || typeof b !== 'object' || Array.isArray(b)) return false;
+    if (typeof b.type !== 'string' || typeof b.partner !== 'string') return false;
+  }
+
+  return true;
+}

--- a/src/games/diplomacy/agents/strategicIntent.test.js
+++ b/src/games/diplomacy/agents/strategicIntent.test.js
@@ -1,0 +1,60 @@
+import { validateStrategicIntent, STRATEGIC_INTENT_SCHEMA } from './strategicIntent.js';
+
+const VALID = {
+  power: 'france',
+  allies: ['germany'],
+  targets: ['italy'],
+  supportDeals: [{ from: 'france', to: 'germany' }],
+  dmz: ['pie', 'tyr'],
+  betrayals: [{ type: 'non-aggression', partner: 'germany' }],
+};
+
+describe('validateStrategicIntent', () => {
+  test('accepts the canonical example from the issue', () => {
+    expect(validateStrategicIntent(VALID)).toBe(true);
+  });
+
+  test('accepts an empty-ish intent (no deals)', () => {
+    expect(
+      validateStrategicIntent({ power: 'italy', allies: [], targets: [], supportDeals: [], dmz: [], betrayals: [] })
+    ).toBe(true);
+  });
+
+  test('rejects null / non-object without throwing', () => {
+    expect(validateStrategicIntent(null)).toBe(false);
+    expect(validateStrategicIntent('nope')).toBe(false);
+    expect(validateStrategicIntent([])).toBe(false);
+  });
+
+  test('rejects a missing or empty power', () => {
+    expect(validateStrategicIntent({ ...VALID, power: '' })).toBe(false);
+    const { power, ...noPower } = VALID;
+    expect(validateStrategicIntent(noPower)).toBe(false);
+  });
+
+  test('rejects non-string-array allies / targets / dmz', () => {
+    expect(validateStrategicIntent({ ...VALID, allies: 'germany' })).toBe(false);
+    expect(validateStrategicIntent({ ...VALID, targets: [1, 2] })).toBe(false);
+    expect(validateStrategicIntent({ ...VALID, dmz: [{}] })).toBe(false);
+  });
+
+  test('rejects malformed supportDeals', () => {
+    expect(validateStrategicIntent({ ...VALID, supportDeals: [{ from: 'france' }] })).toBe(false);
+    expect(validateStrategicIntent({ ...VALID, supportDeals: ['france>germany'] })).toBe(false);
+  });
+
+  test('rejects malformed betrayals', () => {
+    expect(validateStrategicIntent({ ...VALID, betrayals: [{ partner: 'germany' }] })).toBe(false);
+    expect(validateStrategicIntent({ ...VALID, betrayals: [{ type: 'support', partner: 5 }] })).toBe(false);
+  });
+
+  test('rejects stray keys outside the contract', () => {
+    expect(validateStrategicIntent({ ...VALID, extra: true })).toBe(false);
+  });
+
+  test('exports a schema description for downstream assertions', () => {
+    expect(Object.keys(STRATEGIC_INTENT_SCHEMA).sort()).toEqual(
+      ['allies', 'betrayals', 'dmz', 'power', 'supportDeals', 'targets']
+    );
+  });
+});

--- a/src/games/diplomacy/agents/trustModel.js
+++ b/src/games/diplomacy/agents/trustModel.js
@@ -1,0 +1,241 @@
+// Deterministic trust update for the Diplomacy agents (PR1 of [AI Negotiation]).
+//
+// After each movement adjudication, diff the promises a power made during
+// negotiation against what its units ACTUALLY did this turn (board.orderHistory[0])
+// and move trust accordingly. Verified promises are cleared; durable promises are
+// promoted to standing agreements. Pure: no React, no network, no LLM.
+//
+// Why the acting power is stored on the promise: `board.orderHistory[k].orders`
+// is keyed by unit LOCATION and the unit objects are mutated each turn and do not
+// carry their owning power. So a promise like "france supports germany's mun->ruh"
+// can only be attributed correctly if we recorded which power (france) was on the
+// hook — we detect kept/broken off that recorded `actingPower`, never by guessing
+// ownership from the post-adjudication board.
+
+import { baseProvince } from '../DiplomacyBoard.js';
+import {
+  relationKey,
+  recordAgreement,
+  getLedger,
+} from './diplomaticState.js';
+
+// Trust deltas (tunable). Centralized so PR3's reputation-cost model reuses the
+// exact same magnitudes. A single kept support (+0.15) is intentionally smaller
+// than a broken one (-0.40) so cheap promises can't be farmed for trust.
+export const TRUST_DELTAS = {
+  supportKept: 0.15,
+  supportBroken: -0.4,
+  nonAggressionBroken: -0.5,
+  jointAttackHonored: 0.2, // applied mutually to both parties
+};
+
+const TRUST_MIN = -1;
+const TRUST_MAX = 1;
+
+function clampTrust(t) {
+  return Math.max(TRUST_MIN, Math.min(TRUST_MAX, t));
+}
+
+// Normalize a location to its base province, case-insensitively. Promises are
+// recorded from negotiation (often lower-case province ids, per the issue
+// schema) while the engine keys orders by upper-case province id; comparing on
+// an upper-cased base makes the diff robust to either convention.
+function normBase(loc) {
+  const base = baseProvince(loc);
+  return typeof base === 'string' ? base.toUpperCase() : base;
+}
+
+// Did `actingPower` actually issue the support order this promise required?
+// `expectedOrder` is the order shape recorded at negotiation time, e.g.
+//   { type: 'support-move', unitLoc: 'bur', from: 'mun', to: 'ruh' }
+//   { type: 'support-hold', unitLoc: 'bur', target: 'mun' }
+// We match against the resolved orders by unit location, comparing on base
+// provinces so a coast suffix (e.g. STP/sc) never causes a false mismatch.
+function supportPromiseKept(expectedOrder, orders) {
+  if (!expectedOrder || !orders) return false;
+  const actual = orders[expectedOrder.unitLoc];
+  if (!actual || actual.type !== expectedOrder.type) return false;
+
+  if (expectedOrder.type === 'support-move') {
+    return (
+      normBase(actual.from) === normBase(expectedOrder.from) &&
+      normBase(actual.to) === normBase(expectedOrder.to)
+    );
+  }
+  if (expectedOrder.type === 'support-hold') {
+    return normBase(actual.target) === normBase(expectedOrder.target);
+  }
+  return false;
+}
+
+// Apply a directional trust delta and return a fresh relations object. Seeds the
+// relation entry if it is missing (e.g. a power revived since state creation).
+function bumpTrust(relations, from, to, delta, phase) {
+  const key = relationKey(from, to);
+  const prev = relations[key] || { trust: 0, lastUpdatedPhase: null };
+  return {
+    ...relations,
+    [key]: { trust: clampTrust(prev.trust + delta), lastUpdatedPhase: phase },
+  };
+}
+
+// Increment a ledger counter (kept|broken) for a directional pair.
+function bumpLedger(ledger, from, to, field) {
+  const key = relationKey(from, to);
+  const prev = ledger[key] || { kept: 0, broken: 0 };
+  return { ...ledger, [key]: { ...prev, [field]: prev[field] + 1 } };
+}
+
+// Did `actingPower` move a unit into any province the partner occupied at the
+// start of this turn, or into a DMZ province? Used for non-aggression / DMZ
+// violation detection. Partner occupancy is read from the PRE-adjudication board
+// snapshot captured in the order set (orders are keyed by the mover's location),
+// while DMZ provinces come straight off the agreement.
+function violatedNonAggression(actingPower, agreement, orders, partnerOccupied, phase) {
+  // Find every move issued this turn and check its destination base province.
+  const dmz = agreement.type === 'dmz' && Array.isArray(agreement.provinces)
+    ? new Set(agreement.provinces.map(normBase))
+    : new Set();
+
+  for (const order of Object.values(orders)) {
+    if (!order || order.type !== 'move' || !order.to) continue;
+    const dest = normBase(order.to);
+    if (dmz.has(dest)) return true;
+    if (partnerOccupied.has(dest)) return true;
+  }
+  return false;
+}
+
+// updateTrustAfterAdjudication(state, board, { actingPowers }) -> new state.
+//
+// Diffs `state.promises` against `board.orderHistory[0]`, classifies each as
+// kept/broken, applies the trust deltas + ledger bumps, clears verified promises,
+// and promotes durable promises to agreements. Also penalizes non-aggression /
+// DMZ violations for the supplied acting powers.
+//
+//   actingPowers: the powers whose orders resolved this turn. Required to detect
+//                 violations (whose move was it?) since orderHistory doesn't store
+//                 power. A move's owner is resolved via each acting power's
+//                 promise/agreement record + the order locations they were on.
+//
+// Pure: the input `state` is never mutated; a brand-new state object is returned.
+export function updateTrustAfterAdjudication(state, board, { actingPowers = [] } = {}) {
+  const history = Array.isArray(board?.orderHistory) ? board.orderHistory : [];
+  const latest = history[0];
+  // Nothing to verify against (e.g. retreat/adjustment-only history entry).
+  if (!latest || !latest.orders) return state;
+
+  const phase = latest.phase || null;
+  const orders = latest.orders;
+
+  let relations = state.relations;
+  let promiseLedger = state.promiseLedger;
+  const verifiedIds = new Set();
+  let next = state; // accumulates agreement promotions via recordAgreement
+
+  // 1) Verify each recorded support promise against the resolved orders.
+  for (const promise of state.promises) {
+    if (promise.type !== 'support') continue; // only support is order-verifiable
+    const actor = promise.actingPower;
+    if (!actor || (actingPowers.length && !actingPowers.includes(actor))) continue;
+
+    const kept = supportPromiseKept(promise.expectedOrder, orders);
+    const partner = promise.to;
+    if (kept) {
+      relations = bumpTrust(relations, partner, actor, TRUST_DELTAS.supportKept, phase);
+      promiseLedger = bumpLedger(promiseLedger, actor, partner, 'kept');
+    } else {
+      relations = bumpTrust(relations, partner, actor, TRUST_DELTAS.supportBroken, phase);
+      promiseLedger = bumpLedger(promiseLedger, actor, partner, 'broken');
+    }
+    verifiedIds.add(promise.id);
+  }
+
+  // 2) Penalize non-aggression / DMZ violations by acting powers.
+  //    Partner occupancy is derived per-agreement from the orders the partner
+  //    issued (its move/hold/support unitLoc set marks where it sat this turn).
+  for (const agreement of state.agreements) {
+    if (agreement.type !== 'non-aggression' && agreement.type !== 'dmz') continue;
+    if (!Array.isArray(agreement.parties)) continue;
+
+    for (const actor of agreement.parties) {
+      if (actingPowers.length && !actingPowers.includes(actor)) continue;
+      const partner = agreement.parties.find((p) => p !== actor);
+      if (!partner) continue;
+
+      // Restrict the order set to the actor's units. We can't read power off the
+      // mutated board, so the orchestrator stores each acting power's order
+      // locations on the agreement (actor>locs). Fall back to the full set keyed
+      // by the actor when that map is present.
+      const actorOrders = ordersForActor(latest, agreement, actor, orders);
+      const partnerOccupied = partnerOccupiedProvinces(latest, agreement, partner);
+
+      if (violatedNonAggression(actor, agreement, actorOrders, partnerOccupied, phase)) {
+        relations = bumpTrust(relations, partner, actor, TRUST_DELTAS.nonAggressionBroken, phase);
+        promiseLedger = bumpLedger(promiseLedger, actor, partner, 'broken');
+      }
+    }
+  }
+
+  // Rebuild state with updated relations/ledger and verified promises cleared.
+  next = {
+    ...state,
+    relations,
+    promiseLedger,
+    promises: state.promises.filter((p) => !verifiedIds.has(p.id)),
+  };
+
+  // 3) Promote durable promises (kept supports recorded as ongoing) to standing
+  //    agreements so a maintained support relationship persists across turns.
+  for (const promise of state.promises) {
+    if (!verifiedIds.has(promise.id)) continue;
+    if (promise.type !== 'support' || !promise.durable) continue;
+    if (!supportPromiseKept(promise.expectedOrder, orders)) continue;
+    next = recordAgreement(next, {
+      type: 'support',
+      from: promise.from,
+      to: promise.to,
+      phase,
+    });
+  }
+
+  return next;
+}
+
+// Per-agreement order locations for an acting power. The orchestrator may attach
+// `actorOrderLocs: { [power]: [loc,...] }` to the order-history entry (or the
+// agreement) so we can attribute moves without reading power off the board. When
+// absent, we conservatively use the full order set (callers in PR1 tests supply
+// the locs explicitly via the agreement).
+function ordersForActor(historyEntry, agreement, actor, orders) {
+  const map =
+    (historyEntry && historyEntry.actorOrderLocs) ||
+    (agreement && agreement.actorOrderLocs) ||
+    null;
+  if (map && Array.isArray(map[actor])) {
+    const subset = {};
+    for (const loc of map[actor]) if (orders[loc]) subset[loc] = orders[loc];
+    return subset;
+  }
+  return orders;
+}
+
+// Provinces the partner occupied this turn. From an explicit per-power location
+// map when present; otherwise from `agreement.partnerOccupied` (a province list
+// the orchestrator recorded at negotiation time).
+function partnerOccupiedProvinces(historyEntry, agreement, partner) {
+  const map =
+    (historyEntry && historyEntry.actorOrderLocs) ||
+    (agreement && agreement.actorOrderLocs) ||
+    null;
+  if (map && Array.isArray(map[partner])) {
+    return new Set(map[partner].map(normBase));
+  }
+  if (Array.isArray(agreement.partnerOccupied)) {
+    return new Set(agreement.partnerOccupied.map(normBase));
+  }
+  return new Set();
+}
+
+// Re-export so PR3 imports the ledger getter alongside the deltas if it wants.
+export { getLedger };

--- a/src/games/diplomacy/agents/trustModel.test.js
+++ b/src/games/diplomacy/agents/trustModel.test.js
@@ -1,0 +1,216 @@
+import DiplomacyBoard from '../DiplomacyBoard.js';
+import { createDiplomaticState, recordPromise, recordAgreement, getTrust, getLedger } from './diplomaticState.js';
+import { TRUST_DELTAS, updateTrustAfterAdjudication } from './trustModel.js';
+
+// A minimal stand-in for the board: trust diffing only reads orderHistory and
+// baseProvince (a pure import), so a plain object with orderHistory + getPowerIds
+// is all updateTrustAfterAdjudication needs. We seed real state off a real board.
+function stateWith(extra = {}) {
+  const board = new DiplomacyBoard();
+  return { board, state: createDiplomaticState({ board, humanPower: 'england' }), ...extra };
+}
+
+function historyBoard(entry) {
+  return { orderHistory: [entry] };
+}
+
+describe('updateTrustAfterAdjudication — support promises', () => {
+  test('kept support: matching order raises trust and records kept===1', () => {
+    let { state } = stateWith();
+    state = recordPromise(state, {
+      id: 'p1',
+      type: 'support',
+      from: 'france',
+      to: 'germany',
+      actingPower: 'france',
+      expectedOrder: { type: 'support-move', unitLoc: 'bur', from: 'mun', to: 'ruh' },
+    });
+
+    const board = historyBoard({
+      phase: 'Fall 1902',
+      orders: { bur: { type: 'support-move', unitLoc: 'bur', from: 'mun', to: 'ruh' } },
+      resolved: { moveSuccess: {}, cutSupports: [], dislodged: [], strengths: {} },
+    });
+
+    const next = updateTrustAfterAdjudication(state, board, { actingPowers: ['france'] });
+    expect(getTrust(next, 'germany', 'france')).toBeCloseTo(TRUST_DELTAS.supportKept, 5);
+    expect(getLedger(next, 'france', 'germany')).toEqual({ kept: 1, broken: 0 });
+    // Verified promise cleared.
+    expect(next.promises).toHaveLength(0);
+  });
+
+  test('broken support: actual order differs lowers trust and records broken===1', () => {
+    let { state } = stateWith();
+    state = recordPromise(state, {
+      id: 'p1',
+      type: 'support',
+      from: 'france',
+      to: 'germany',
+      actingPower: 'france',
+      expectedOrder: { type: 'support-move', unitLoc: 'bur', from: 'mun', to: 'ruh' },
+    });
+
+    // France instead moved bur->mar (selfish), breaking the promise.
+    const board = historyBoard({
+      phase: 'Fall 1902',
+      orders: { bur: { type: 'move', unitLoc: 'bur', to: 'mar' } },
+      resolved: { moveSuccess: { bur: true }, cutSupports: [], dislodged: [], strengths: {} },
+    });
+
+    const next = updateTrustAfterAdjudication(state, board, { actingPowers: ['france'] });
+    expect(getTrust(next, 'germany', 'france')).toBeCloseTo(TRUST_DELTAS.supportBroken, 5);
+    expect(getLedger(next, 'france', 'germany')).toEqual({ kept: 0, broken: 1 });
+  });
+
+  test('coast suffix on actual order still counts as kept', () => {
+    let { state } = stateWith();
+    state = recordPromise(state, {
+      id: 'p1', type: 'support', from: 'russia', to: 'turkey', actingPower: 'russia',
+      expectedOrder: { type: 'support-move', unitLoc: 'rum', from: 'bul', to: 'con' },
+    });
+    const board = historyBoard({
+      phase: 'Fall 1902',
+      orders: { rum: { type: 'support-move', unitLoc: 'rum', from: 'BUL/ec', to: 'con' } },
+      resolved: { moveSuccess: {}, cutSupports: [], dislodged: [], strengths: {} },
+    });
+    const next = updateTrustAfterAdjudication(state, board, { actingPowers: ['russia'] });
+    expect(getLedger(next, 'russia', 'turkey')).toEqual({ kept: 1, broken: 0 });
+  });
+});
+
+describe('updateTrustAfterAdjudication — non-aggression / DMZ violations', () => {
+  test('a france-unit move into a germany-occupied province lowers trust', () => {
+    let { state } = stateWith();
+    state = recordAgreement(state, {
+      id: 'a1',
+      type: 'non-aggression',
+      parties: ['france', 'germany'],
+      // The orchestrator records where each power sat / what it ordered this turn.
+      actorOrderLocs: { france: ['bur'], germany: ['mun', 'ruh'] },
+    });
+
+    // France's bur moved into mun (a province Germany occupied).
+    const board = historyBoard({
+      phase: 'Fall 1902',
+      orders: {
+        bur: { type: 'move', unitLoc: 'bur', to: 'mun' },
+        mun: { type: 'hold', unitLoc: 'mun' },
+        ruh: { type: 'hold', unitLoc: 'ruh' },
+      },
+      resolved: { moveSuccess: { bur: false }, cutSupports: [], dislodged: [], strengths: {} },
+    });
+
+    const next = updateTrustAfterAdjudication(state, board, { actingPowers: ['france', 'germany'] });
+    expect(getTrust(next, 'germany', 'france')).toBeCloseTo(TRUST_DELTAS.nonAggressionBroken, 5);
+    // Germany did not aggress, so France's trust toward Germany is unchanged.
+    expect(getTrust(next, 'france', 'germany')).toBe(0);
+  });
+
+  test('DMZ violation: moving into a DMZ province lowers trust', () => {
+    let { state } = stateWith();
+    state = recordAgreement(state, {
+      id: 'a2',
+      type: 'dmz',
+      parties: ['france', 'italy'],
+      provinces: ['pie', 'tyr'],
+      actorOrderLocs: { france: ['mar'], italy: ['ven'] },
+    });
+    const board = historyBoard({
+      phase: 'Fall 1902',
+      orders: {
+        mar: { type: 'move', unitLoc: 'mar', to: 'pie' }, // into the DMZ
+        ven: { type: 'hold', unitLoc: 'ven' },
+      },
+      resolved: { moveSuccess: { mar: true }, cutSupports: [], dislodged: [], strengths: {} },
+    });
+    const next = updateTrustAfterAdjudication(state, board, { actingPowers: ['france', 'italy'] });
+    expect(getTrust(next, 'italy', 'france')).toBeCloseTo(TRUST_DELTAS.nonAggressionBroken, 5);
+  });
+
+  test('acting-power resolution: two powers moving to the same province — no misattribution', () => {
+    let { state } = stateWith();
+    // Non-aggression between france and germany. Italy ALSO moves into mun, but
+    // Italy is not a party, so France must NOT be blamed for Italy's move.
+    state = recordAgreement(state, {
+      id: 'a1',
+      type: 'non-aggression',
+      parties: ['france', 'germany'],
+      actorOrderLocs: { france: ['bur'], germany: ['mun'] },
+    });
+    const board = historyBoard({
+      phase: 'Fall 1902',
+      orders: {
+        bur: { type: 'hold', unitLoc: 'bur' },     // France stayed put — honored
+        tyr: { type: 'move', unitLoc: 'tyr', to: 'mun' }, // Italy attacked mun
+        mun: { type: 'hold', unitLoc: 'mun' },
+      },
+      resolved: { moveSuccess: { tyr: false }, cutSupports: [], dislodged: [], strengths: {} },
+    });
+    const next = updateTrustAfterAdjudication(state, board, { actingPowers: ['france', 'germany'] });
+    // France honored; trust toward France unchanged.
+    expect(getTrust(next, 'germany', 'france')).toBe(0);
+    expect(getLedger(next, 'france', 'germany')).toEqual({ kept: 0, broken: 0 });
+  });
+});
+
+describe('updateTrustAfterAdjudication — invariants', () => {
+  test('trust is clamped to [-1, 1] over repeated breaks', () => {
+    let { state } = stateWith();
+    const board = historyBoard({
+      phase: 'Fall 1902',
+      orders: { bur: { type: 'move', unitLoc: 'bur', to: 'mar' } },
+      resolved: { moveSuccess: {}, cutSupports: [], dislodged: [], strengths: {} },
+    });
+    for (let i = 0; i < 5; i++) {
+      state = recordPromise(state, {
+        id: `p${i}`, type: 'support', from: 'france', to: 'germany', actingPower: 'france',
+        expectedOrder: { type: 'support-move', unitLoc: 'bur', from: 'mun', to: 'ruh' },
+      });
+      state = updateTrustAfterAdjudication(state, board, { actingPowers: ['france'] });
+    }
+    expect(getTrust(state, 'germany', 'france')).toBe(-1);
+  });
+
+  test('is pure — the input state is deep-equal before and after', () => {
+    let { state } = stateWith();
+    state = recordPromise(state, {
+      id: 'p1', type: 'support', from: 'france', to: 'germany', actingPower: 'france',
+      expectedOrder: { type: 'support-move', unitLoc: 'bur', from: 'mun', to: 'ruh' },
+    });
+    const before = JSON.parse(JSON.stringify(state));
+    const board = historyBoard({
+      phase: 'Fall 1902',
+      orders: { bur: { type: 'support-move', unitLoc: 'bur', from: 'mun', to: 'ruh' } },
+      resolved: { moveSuccess: {}, cutSupports: [], dislodged: [], strengths: {} },
+    });
+    updateTrustAfterAdjudication(state, board, { actingPowers: ['france'] });
+    expect(state).toEqual(before);
+  });
+
+  test('negative: an unrelated order causes zero trust change', () => {
+    let { state } = stateWith();
+    state = recordPromise(state, {
+      id: 'p1', type: 'support', from: 'france', to: 'germany', actingPower: 'france',
+      expectedOrder: { type: 'support-move', unitLoc: 'bur', from: 'mun', to: 'ruh' },
+    });
+    // Only turkey moved; france issued no order at all this turn.
+    const board = historyBoard({
+      phase: 'Fall 1902',
+      orders: { ank: { type: 'move', unitLoc: 'ank', to: 'con' } },
+      resolved: { moveSuccess: { ank: true }, cutSupports: [], dislodged: [], strengths: {} },
+    });
+    // France's promise is verified (it acted by NOT issuing the support) and so
+    // counts as broken — but a power NOT in actingPowers is skipped entirely.
+    const next = updateTrustAfterAdjudication(state, board, { actingPowers: ['turkey'] });
+    expect(getTrust(next, 'germany', 'france')).toBe(0);
+    expect(getLedger(next, 'france', 'germany')).toEqual({ kept: 0, broken: 0 });
+    // Promise untouched because france didn't resolve this turn.
+    expect(next.promises).toHaveLength(1);
+  });
+
+  test('no orders entry (retreat/adjustment turn) is a no-op', () => {
+    const { state } = stateWith();
+    const board = { orderHistory: [{ phase: 'Winter 1902', adjustments: {} }] };
+    expect(updateTrustAfterAdjudication(state, board, { actingPowers: ['france'] })).toBe(state);
+  });
+});


### PR DESCRIPTION
## Summary
Builds the negotiation + intent-formation layer for Diplomacy (all three planned PRs of #28 in one branch): a persisted per-power diplomatic state, deterministic trust updates diffed against `orderHistory`, a bounded private AI-to-AI negotiation orchestrator, and a betrayal/decision model that emits the strategic-intent contract [Intent Binding]/[Tactical AI] consume. AI powers can now form alliances, coordinate, lie, and betray behind the human's back — the human sees only the consequences and whatever an AI tells them directly.

Closes #28

## Validation evidence

### Tests
- `CI=true npm test` — full suite green: **37 suites, 725 tests passing**.
- New: `diplomaticState.test.js`, `trustModel.test.js`, `negotiator.test.js`, `betrayalModel.test.js`, `strategicIntent.test.js` (52 new tests). The LLM is mocked via an injected call-counting `askAgent`; **no real key in CI**.
- Asserted: exact AI-to-AI call budget (`<= maxRounds*maxPairsPerRound`, scales R*N) and `<= 1` human-thread call/AI; deterministic pair selection by seed; mocked support-deal -> recorded promise; accepted DMZ -> dmz agreement; **secrecy negative** (AI-to-AI text never in the human thread store); dead powers never selected; trust clamp; purity/deep-equal of inputs; acting-power no-misattribution; honor-vs-betray; schema conformance for every alive AI power.

### Manual verification
- `npm run build` completes without errors.
- Grep-asserted PR1/PR3 purity: no React/fetch/localStorage in `diplomaticState.js`, `trustModel.js`, `betrayalModel.js`, `strategicIntent.js`; no cross-game imports anywhere under `agents/`.

## Affected areas
- **New (pure):** `agents/diplomaticState.js`, `agents/trustModel.js`, `agents/betrayalModel.js`, `agents/strategicIntent.js`
- **New (orchestrator):** `agents/negotiator.js` (client-side, off the render path, LLM injected)
- **Extended:** `agents/agentClient.js` (`askAgent` wrapping the reused BYO-key endpoint), `api/diplomacyAgent.js` (optional `counterparties`/`channel`, CORS + BYO invariants preserved)
- **Dependencies:** none

## Review focus
- Trust kept/broken classification keying off the acting power recorded on each deal (orderHistory units are mutated and don't store power).
- Secrecy boundary: AI-to-AI transcripts (returned, keyed by channel) vs the human-visible thread store (only messages addressed to the human).
- The betrayal decision rule and that `supportDeals`/`betrayals` stay disjoint and partition the standing support agreements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)