### PR TITLE
feat(diplomacy): negotiation-phase turn loop + full save/resume

### DIFF
--- a/src/games/diplomacy/DiplomacyGame.jsx
+++ b/src/games/diplomacy/DiplomacyGame.jsx
@@ -1,13 +1,15 @@
 // DiplomacyGame.jsx - React UI + SVG rendering for classic Diplomacy.
 //
-// Hot-seat baseline: a human enters every power's orders before a single
-// "Submit orders" resolves the turn (Diplomacy is simultaneous). All legal
-// options are sourced from the engine (getLegalOrdersForUnit / getMoveTargets /
-// getRetreatOptions / getLegalAdjustmentOrders) — the UI never computes
-// adjacency itself. The per-power `controller` ('human' | 'ai') is the seam for
-// later AI issues; 'ai' powers placeholder-hold at submit (no AI logic here).
+// Full playable loop ([Negotiation Loop]): new-game setup -> per-season
+// negotiation (human chat + bounded AI↔AI) -> the human enters only their own
+// power's orders while AI powers are computed via intent binding + tactical AI ->
+// adjudicate -> retreats -> winter -> next season, vs six AI powers, with full
+// versioned save/resume. The turn orchestration lives in useDiplomacyTurn; the
+// engine (DiplomacyBoard) stays pure logic, consumed via clone/applyMove/
+// serializeState only. All legal options are sourced from the engine — the UI
+// never computes adjacency itself.
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import DiplomacyBoard, {
   POWERS,
@@ -16,12 +18,25 @@ import DiplomacyBoard, {
   POWER_COLORS,
   POWER_ACCENTS,
   PROVINCES,
-  SUPPLY_CENTERS,
   baseProvince,
   coastOf,
   formatUnitType,
 } from './DiplomacyBoard.js';
 import ChatPanel from './agents/ChatPanel.jsx';
+import { createMemory } from './agents/memory.js';
+import { createDiplomaticState } from './agents/diplomaticState.js';
+import { PERSONAS } from './agents/personas.js';
+import { hasApiKey } from './agents/agentClient.js';
+import useAIWorker from './hooks/useAIWorker.js';
+import useDiplomacyTurn from './hooks/useDiplomacyTurn.js';
+import DiplomacySetup from './DiplomacySetup.jsx';
+import {
+  loadSettings,
+  saveSettings,
+  buildControllers,
+  budgetForDifficulty,
+} from './diplomacySettings.js';
+import { saveGame, loadGame, clearGame } from './diplomacyPersistence.js';
 import './diplomacy.css';
 
 // ----- viewBox computed from PROVINCES coords + padding (nothing clipped) -----
@@ -80,31 +95,113 @@ function describeOrder(order) {
   }
 }
 
-function defaultControllers() {
-  // All powers default to human (hot-seat). 'ai' is the reserved seam.
-  return Object.fromEntries(POWERS.map(power => [power, 'human']));
+// Personas for every power (the persona shape persisted in the save).
+function defaultPersonas() {
+  return { ...PERSONAS };
 }
 
 export default function DiplomacyGame() {
-  const [board, setBoard] = useState(() => new DiplomacyBoard());
+  // ----- one-time mount restore: resume a saved game if one exists -----
+  const restoredRef = useRef(null);
+  if (restoredRef.current === null) {
+    restoredRef.current = safeLoad();
+  }
+  const restored = restoredRef.current;
+
+  const [settings, setSettings] = useState(loadSettings);
+  const [inGame, setInGame] = useState(() => !!restored);
+
+  const [board, setBoardState] = useState(() =>
+    restored
+      ? DiplomacyBoard.fromSerializedState(restored.board)
+      : new DiplomacyBoard({ maxYears: settings.maxYears })
+  );
+  const [controllers, setControllers] = useState(() =>
+    restored && restored.controllers ? restored.controllers : buildControllers(settings.power)
+  );
+  const [personas, setPersonas] = useState(() =>
+    restored && restored.personas ? restored.personas : defaultPersonas()
+  );
+  // Human-VISIBLE conversation store (memory of the human↔AI chat threads).
+  const [conversations, setConversations] = useState(() => {
+    if (restored && restored.conversations) return restored.conversations;
+    const ai = POWERS.filter((p) => p !== settings.power);
+    return createMemory(ai);
+  });
+  // Hidden AI↔AI diplomatic state — never rendered.
+  const [diplomaticState, setDiplomaticState] = useState(() => {
+    if (restored && restored.diplomaticState) return restored.diplomaticState;
+    const b = restored ? DiplomacyBoard.fromSerializedState(restored.board) : board;
+    try {
+      return createDiplomaticState({ board: b, humanPower: settings.power });
+    } catch (_) {
+      return null;
+    }
+  });
+
+  const humanPower = useMemo(
+    () => POWERS.find((p) => controllers[p] === 'human') || settings.power,
+    [controllers, settings.power]
+  );
+  const difficultyBudget = useMemo(() => budgetForDifficulty(settings.difficulty), [settings.difficulty]);
+
   const [darkMode, setDarkMode] = useState(() => JSON.parse(localStorage.getItem('diplomacyDarkMode') || 'false'));
   const [showOrders, setShowOrders] = useState(() => JSON.parse(localStorage.getItem('diplomacyShowOrders') || 'true'));
-  const [controllers] = useState(defaultControllers);
+  const [confirmNew, setConfirmNew] = useState(false);
+  const [keyPromptDismissed, setKeyPromptDismissed] = useState(false);
 
-  const [activePower, setActivePower] = useState(POWERS[0]);
-  // pendingOrdersByPower[power] = { [unitLoc]: orderObject }
-  const [pendingOrders, setPendingOrders] = useState({});
-  // In-progress order entry: { unitLoc, type } once a unit + type are chosen.
+  // Transient order-entry state (human power only).
+  const [pendingOrders, setPendingOrders] = useState({}); // { [unitLoc]: order }
   const [selectedUnit, setSelectedUnit] = useState(null);
   const [orderType, setOrderType] = useState(null);
-  // Retreat phase: { [unitLoc]: 'DISBAND' | targetLoc }
-  const [retreatChoices, setRetreatChoices] = useState({});
-  // Winter phase: pending adjustment orders per power (array).
-  const [buildOrders, setBuildOrders] = useState({});
-  const [confirmNew, setConfirmNew] = useState(false);
+  const [retreatChoices, setRetreatChoices] = useState({}); // { [unitLoc]: 'DISBAND'|to }
+  const [buildOrders, setBuildOrders] = useState({}); // { [power]: order[] }
+
+  const { computeOrders, isSupported: workerSupported } = useAIWorker();
 
   useEffect(() => localStorage.setItem('diplomacyDarkMode', JSON.stringify(darkMode)), [darkMode]);
   useEffect(() => localStorage.setItem('diplomacyShowOrders', JSON.stringify(showOrders)), [showOrders]);
+
+  const setBoard = useCallback((next) => setBoardState(next), []);
+
+  // Persist the whole game after each phase transition the hook settles.
+  const onPhaseSettled = useCallback(
+    ({ uiPhase: ph, diplomaticState: ds }) => {
+      saveGame({
+        board,
+        uiPhase: ph,
+        controllers,
+        personas,
+        conversations,
+        diplomaticState: ds !== undefined ? ds : diplomaticState,
+      });
+    },
+    [board, controllers, personas, conversations, diplomaticState]
+  );
+
+  const turn = useDiplomacyTurn({
+    board,
+    setBoard,
+    controllers,
+    humanPower,
+    difficultyBudget,
+    diplomaticState,
+    setDiplomaticState,
+    personas,
+    conversations,
+    workerSupported,
+    computeOrders,
+    onPhaseSettled,
+  });
+
+  // Restore the saved UI phase exactly once after a resume.
+  const uiRestoredRef = useRef(false);
+  useEffect(() => {
+    if (!uiRestoredRef.current && restored && restored.uiPhase) {
+      turn.restoreUiPhase(restored.uiPhase);
+      uiRestoredRef.current = true;
+    }
+  }, [restored, turn]);
 
   // Reset transient entry state whenever the phase/turn changes.
   useEffect(() => {
@@ -113,19 +210,22 @@ export default function DiplomacyGame() {
     setOrderType(null);
     setRetreatChoices({});
     setBuildOrders({});
-  }, [board.phase, board.year, board.season]);
+  }, [board.phase, board.year, board.season, turn.uiPhase]);
+
+  // Persist whenever the board reference changes (every applied move) so a save
+  // exists even outside the explicit settle calls.
+  const persistRef = useRef(null);
+  persistRef.current = { board, uiPhase: turn.uiPhase, controllers, personas, conversations, diplomaticState };
+  useEffect(() => {
+    if (!inGame) return;
+    saveGame(persistRef.current);
+  }, [board, turn.uiPhase, inGame]);
 
   const phaseLabel = board.getPhaseLabel();
   const leader = board.getLeader();
+  const activeUnits = useMemo(() => board.getUnits(humanPower), [board, humanPower]);
 
-  const humanPowers = useMemo(() => POWERS.filter(power => controllers[power] === 'human'), [controllers]);
-
-  // Units owned by the active power that can be ordered this phase.
-  const activeUnits = useMemo(() => board.getUnits(activePower), [board, activePower]);
-
-  const refresh = () => setBoard(board.clone());
-
-  // ----- Orders phase: order construction (all options from the engine) -----
+  // ----- order construction (human power only; options from the engine) -----
   const legalForSelected = useMemo(() => {
     if (!selectedUnit) return [];
     return board.getLegalOrdersForUnit(selectedUnit);
@@ -141,72 +241,47 @@ export default function DiplomacyGame() {
     return legalForSelected.filter(o => o.type === orderType);
   }, [legalForSelected, selectedUnit, orderType]);
 
+  const isOrderEntry = board.isOrdersPhase() && turn.uiPhase === 'orders';
+
   function selectUnitForOrder(loc) {
     const unit = board.units[loc];
-    if (!unit || unit.power !== activePower || !board.isOrdersPhase()) return;
+    if (!unit || unit.power !== humanPower || !isOrderEntry) return;
     setSelectedUnit(loc);
     setOrderType(null);
   }
 
-  function setPendingOrder(power, order) {
-    setPendingOrders(prev => ({
-      ...prev,
-      [power]: { ...(prev[power] || {}), [order.unitLoc]: order },
-    }));
+  function setPendingOrder(order) {
+    setPendingOrders(prev => ({ ...prev, [order.unitLoc]: order }));
     setSelectedUnit(null);
     setOrderType(null);
   }
 
   function chooseOrderType(type) {
     setOrderType(type);
-    // Hold has no target — commit immediately.
-    if (type === 'hold') {
-      setPendingOrder(activePower, { type: 'hold', unitLoc: selectedUnit });
-    }
+    if (type === 'hold') setPendingOrder({ type: 'hold', unitLoc: selectedUnit });
   }
 
-  function clearOrderFor(power, unitLoc) {
+  function clearOrderFor(unitLoc) {
     setPendingOrders(prev => {
-      const next = { ...(prev[power] || {}) };
+      const next = { ...prev };
       delete next[unitLoc];
-      return { ...prev, [power]: next };
+      return next;
     });
   }
 
   function submitOrders() {
-    const ordersByPower = {};
-    for (const power of POWERS) {
-      if (controllers[power] === 'ai') {
-        // Placeholder: AI powers hold every unit (no AI logic in this issue).
-        ordersByPower[power] = board.getUnits(power).map(u => ({ type: 'hold', unitLoc: u.loc }));
-        continue;
-      }
-      const entered = pendingOrders[power] || {};
-      ordersByPower[power] = board.getUnits(power).map(u => entered[u.loc] || { type: 'hold', unitLoc: u.loc });
-    }
-    board.applyMove({ type: 'orders', ordersByPower });
-    refresh();
+    turn.submitOrders({ [humanPower]: pendingOrders });
   }
 
-  // ----- Retreat phase -----
+  // ----- retreats -----
   function chooseRetreat(unitLoc, value) {
     setRetreatChoices(prev => ({ ...prev, [unitLoc]: value }));
   }
-
   function submitRetreats() {
-    const retreatsByPower = {};
-    for (const pending of board.pendingRetreats) {
-      const power = pending.unit.power;
-      const choice = retreatChoices[pending.unitLoc];
-      const to = !choice || choice === 'DISBAND' ? null : choice;
-      if (!retreatsByPower[power]) retreatsByPower[power] = [];
-      retreatsByPower[power].push({ type: 'retreat', unitLoc: pending.unitLoc, to });
-    }
-    board.applyMove({ type: 'retreats', retreatsByPower });
-    refresh();
+    turn.submitRetreats({ [humanPower]: retreatChoices });
   }
 
-  // ----- Winter phase -----
+  // ----- winter -----
   function toggleBuildOrder(power, order) {
     setBuildOrders(prev => {
       const list = prev[power] || [];
@@ -216,43 +291,60 @@ export default function DiplomacyGame() {
       return { ...prev, [power]: [...list, order] };
     });
   }
-
   function submitAdjustments() {
-    const adjustmentsByPower = {};
-    for (const power of POWERS) {
-      adjustmentsByPower[power] = buildOrders[power] || [];
-    }
-    board.applyMove({ type: 'adjustments', adjustmentsByPower });
-    refresh();
+    turn.submitAdjustments(buildOrders);
   }
 
-  // ----- Undo / redo / new game -----
-  function doUndo() {
-    if (board.undo()) refresh();
-  }
-  function doRedo() {
-    if (board.redo()) refresh();
-  }
-  function newGame() {
+  // ----- new game / setup -----
+  function startGame(chosen) {
+    const next = { ...settings, ...chosen };
+    setSettings(next);
+    saveSettings(next);
+    clearGame();
+    const fresh = new DiplomacyBoard({ maxYears: next.maxYears });
+    const ctrls = buildControllers(next.power);
+    const ai = POWERS.filter((p) => p !== next.power);
+    setBoardState(fresh);
+    setControllers(ctrls);
+    setPersonas(defaultPersonas());
+    setConversations(createMemory(ai));
+    try {
+      setDiplomaticState(createDiplomaticState({ board: fresh, humanPower: next.power }));
+    } catch (_) {
+      setDiplomaticState(null);
+    }
     setConfirmNew(false);
-    setBoard(new DiplomacyBoard());
+    setKeyPromptDismissed(false);
+    uiRestoredRef.current = true; // don't re-restore an old phase
+    turn.setUiPhase('negotiation');
+    setInGame(true);
   }
 
-  // ----- Pending-order overlays for the active power (+ already-entered ones) -----
-  const overlayOrders = useMemo(() => {
-    if (!showOrders) return [];
-    const all = [];
-    for (const power of POWERS) {
-      const entered = pendingOrders[power] || {};
-      for (const order of Object.values(entered)) {
-        all.push({ power, order });
-      }
-    }
-    return all;
-  }, [pendingOrders, showOrders]);
+  function returnToSetup() {
+    clearGame();
+    setConfirmNew(false);
+    setInGame(false);
+  }
 
   const adjustments = board.isWinterPhase() ? board.getAdjustments() : null;
   const lastLog = board.orderHistory[0] || null;
+
+  // Pending-order overlays for the human power.
+  const overlayOrders = useMemo(() => {
+    if (!showOrders) return [];
+    return Object.values(pendingOrders).map(order => ({ power: humanPower, order }));
+  }, [pendingOrders, showOrders, humanPower]);
+
+  const showKeyPrompt = !hasApiKey() && !keyPromptDismissed && inGame;
+
+  // ----- setup gate -----
+  if (!inGame) {
+    return (
+      <div className={`game-diplomacy min-h-screen bg-[var(--dip-bg)] font-body ${darkMode ? 'dark' : ''}`}>
+        <DiplomacySetup initial={settings} onStart={startGame} />
+      </div>
+    );
+  }
 
   return (
     <div className={`game-diplomacy min-h-screen bg-[var(--dip-bg)] font-body ${darkMode ? 'dark' : ''}`}>
@@ -264,7 +356,7 @@ export default function DiplomacyGame() {
               Your current game will be lost.
             </p>
             <div className="mt-6 flex gap-3">
-              <button className="dip-primary-btn flex-1" onClick={newGame}>New Game</button>
+              <button className="dip-primary-btn flex-1" onClick={returnToSetup}>New Game</button>
               <button className="dip-tool-btn flex-1" onClick={() => setConfirmNew(false)}>Cancel</button>
             </div>
           </div>
@@ -283,9 +375,13 @@ export default function DiplomacyGame() {
             </div>
             <div className="dip-phase-banner mt-4">{phaseLabel}</div>
             <div className="dip-last-action mt-2">{board.lastAction}</div>
+            <div className="dip-you-line mt-1">
+              You are <strong style={{ color: POWER_COLORS[humanPower] }}>{POWER_NAMES[humanPower]}</strong>
+            </div>
+            {turn.isBusy && turn.progress && (
+              <div className="dip-progress mt-2" role="status">{turn.progress}</div>
+            )}
             <div className="mt-3 flex flex-wrap gap-2">
-              <button className="dip-tool-btn px-3" onClick={doUndo} disabled={!board.canUndo()} aria-label="Undo last move">Undo</button>
-              <button className="dip-tool-btn px-3" onClick={doRedo} disabled={!board.canRedo()} aria-label="Redo move">Redo</button>
               <button className="dip-tool-btn px-3" onClick={() => setConfirmNew(true)} aria-label="Start a new game">New</button>
             </div>
             <div className="mt-3 space-y-2">
@@ -294,6 +390,16 @@ export default function DiplomacyGame() {
             </div>
           </div>
 
+          {showKeyPrompt && (
+            <div className="dip-keyprompt p-4">
+              <div className="dip-keyprompt-text">
+                Playing without an Anthropic API key: the AI powers still make tactical moves, but
+                won't negotiate or chat. Add a key in the Negotiation panel to enable diplomacy.
+              </div>
+              <button className="dip-keyprompt-dismiss" onClick={() => setKeyPromptDismissed(true)}>Dismiss</button>
+            </div>
+          )}
+
           <div className="dip-panel p-4">
             <div className="dip-panel-label mb-2">Supply Centers</div>
             <div className="dip-scoreboard">
@@ -301,7 +407,7 @@ export default function DiplomacyGame() {
                 .map(power => ({ power, centers: board.getSupplyCount(power), units: board.getUnitCount(power) }))
                 .sort((a, b) => b.centers - a.centers || a.power.localeCompare(b.power))
                 .map(({ power, centers, units }) => (
-                  <div key={power} className={`dip-score-row ${leader.power === power ? 'is-leader' : ''}`}>
+                  <div key={power} className={`dip-score-row ${leader.power === power ? 'is-leader' : ''} ${power === humanPower ? 'is-you' : ''}`}>
                     <span className="dip-score-swatch" style={{ backgroundColor: POWER_COLORS[power] }} aria-hidden="true" />
                     <span className="dip-score-name" style={{ color: 'var(--dip-text)' }}>{POWER_SHORT_NAMES[power]}</span>
                     <span className="dip-score-centers">{centers}</span>
@@ -322,13 +428,12 @@ export default function DiplomacyGame() {
             </div>
           </div>
 
-          {/* Negotiation: talk to the other powers (BYO Anthropic key). The
-              active power is treated as "you"; every other power is an agent. */}
+          {/* Negotiation chat: the human talks to the other powers (BYO key). */}
           <div className="dip-panel p-4">
             <ChatPanel
               board={board}
-              humanPower={activePower}
-              aiPowers={POWERS.filter(p => p !== activePower)}
+              humanPower={humanPower}
+              aiPowers={POWERS.filter(p => p !== humanPower)}
             />
           </div>
         </aside>
@@ -340,7 +445,7 @@ export default function DiplomacyGame() {
           </div>
         </main>
 
-        {/* ---- Right: order entry / retreat / winter / game-over ---- */}
+        {/* ---- Right: negotiation / order entry / retreat / winter / game-over ---- */}
         <aside className="order-3 flex w-full flex-col gap-3 lg:w-[340px]">
           {board.phase === 'game-over' && (
             <div className="dip-panel p-4">
@@ -356,15 +461,50 @@ export default function DiplomacyGame() {
             </div>
           )}
 
-          {board.isOrdersPhase() && renderOrderPanel()}
-          {board.isRetreatPhase() && renderRetreatPanel()}
-          {board.isWinterPhase() && renderWinterPanel()}
+          {board.phase !== 'game-over' && board.isOrdersPhase() && turn.uiPhase === 'negotiation' && renderNegotiationPanel()}
+          {board.phase !== 'game-over' && isOrderEntry && renderOrderPanel()}
+          {board.phase !== 'game-over' && turn.uiPhase === 'resolving' && (
+            <div className="dip-panel p-4">
+              <div className="dip-panel-label mb-2">Resolving</div>
+              <p className="dip-submit-hint">{turn.progress || 'Resolving orders…'}</p>
+            </div>
+          )}
+          {board.phase !== 'game-over' && board.isRetreatPhase() && renderRetreatPanel()}
+          {board.phase !== 'game-over' && board.isWinterPhase() && renderWinterPanel()}
         </aside>
       </div>
     </div>
   );
 
   // ============================ render helpers ============================
+
+  function renderNegotiationPanel() {
+    return (
+      <div className="dip-panel p-4">
+        <div className="dip-panel-label mb-2">Negotiation — {phaseLabel}</div>
+        <p className="dip-submit-hint">
+          Talk to the other powers in the Negotiation panel. When you're ready, proceed to enter
+          your orders. The other powers will plan their moves simultaneously.
+        </p>
+        <div className="mt-4 flex flex-col gap-2">
+          <button
+            className="dip-tool-btn w-full"
+            onClick={turn.runNegotiation}
+            disabled={turn.isBusy}
+          >
+            {turn.isBusy ? 'Powers conferring…' : 'Let the powers confer'}
+          </button>
+          <button
+            className="dip-primary-btn w-full"
+            onClick={turn.proceedToOrders}
+            disabled={turn.isBusy}
+          >
+            Proceed to orders
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   function renderMap() {
     const units = board.getUnits();
@@ -387,9 +527,9 @@ export default function DiplomacyGame() {
         {/* Province nodes */}
         {Object.entries(PROVINCES).map(([id, province]) => {
           const owner = province.supply ? board.supplyCenters[id] : null;
-          const isSelectable = board.isOrdersPhase()
+          const isSelectable = isOrderEntry
             && board.units[id]
-            && board.units[id].power === activePower;
+            && board.units[id].power === humanPower;
           const selectedLoc = board.unitLocAt(id);
           const isSelected = selectedUnit && baseProvince(selectedUnit) === id;
           return (
@@ -471,33 +611,19 @@ export default function DiplomacyGame() {
         />
       );
     }
-    // hold
     return (
       <circle key={key} cx={from.x} cy={from.y} r={14} className="dip-order-hold" style={{ stroke: color }} />
     );
   }
 
   function renderOrderPanel() {
-    const entered = pendingOrders[activePower] || {};
+    const entered = pendingOrders;
     return (
       <>
         <div className="dip-panel p-4">
-          <div className="dip-panel-label mb-2">Order Entry</div>
-          <div className="dip-power-switcher">
-            {humanPowers.map(power => (
-              <button
-                key={power}
-                className={`dip-power-tab ${activePower === power ? 'active' : ''}`}
-                style={{ '--tab-color': POWER_COLORS[power] }}
-                onClick={() => { setActivePower(power); setSelectedUnit(null); setOrderType(null); }}
-              >
-                {POWER_SHORT_NAMES[power]}
-              </button>
-            ))}
-          </div>
-
-          <div className="mt-3 dip-unit-list">
-            {activeUnits.length === 0 && <p className="dip-log-empty">{POWER_SHORT_NAMES[activePower]} has no units.</p>}
+          <div className="dip-panel-label mb-2">Your Orders — {POWER_SHORT_NAMES[humanPower]}</div>
+          <div className="mt-1 dip-unit-list">
+            {activeUnits.length === 0 && <p className="dip-log-empty">{POWER_SHORT_NAMES[humanPower]} has no units.</p>}
             {activeUnits.map(unit => {
               const order = entered[unit.loc];
               const isSelected = selectedUnit === unit.loc;
@@ -508,7 +634,7 @@ export default function DiplomacyGame() {
                     <span className="dip-unit-order">{order ? describeOrder(order) : 'holds (default)'}</span>
                   </button>
                   {order && (
-                    <button className="dip-tool-btn px-2" onClick={() => clearOrderFor(activePower, unit.loc)} aria-label={`Clear order for ${unit.loc}`}>Clear</button>
+                    <button className="dip-tool-btn px-2" onClick={() => clearOrderFor(unit.loc)} aria-label={`Clear order for ${unit.loc}`}>Clear</button>
                   )}
                 </div>
               );
@@ -537,7 +663,7 @@ export default function DiplomacyGame() {
                   <button
                     key={pendingKey(option)}
                     className="dip-target-btn"
-                    onClick={() => setPendingOrder(activePower, option)}
+                    onClick={() => setPendingOrder(option)}
                   >
                     {describeOrder(option)}
                   </button>
@@ -549,23 +675,27 @@ export default function DiplomacyGame() {
 
         <div className="dip-panel p-4">
           <p className="dip-submit-hint">
-            Enter orders for every human power, then resolve the turn. Units with no order will hold.
+            Enter orders for your units, then resolve the turn. Units with no order will hold. The
+            other powers move simultaneously.
           </p>
-          <button className="dip-primary-btn mt-3 w-full" onClick={submitOrders}>Submit Orders</button>
+          <button className="dip-primary-btn mt-3 w-full" onClick={submitOrders} disabled={turn.isBusy}>
+            {turn.isBusy ? 'Resolving…' : 'Submit Orders'}
+          </button>
         </div>
       </>
     );
   }
 
   function renderRetreatPanel() {
+    const humanPending = board.pendingRetreats.filter(p => p.unit.power === humanPower);
     return (
       <div className="dip-panel p-4">
         <div className="dip-panel-label mb-2">Retreats</div>
-        {board.pendingRetreats.length === 0 ? (
-          <p className="dip-log-empty">No retreats pending.</p>
+        {humanPending.length === 0 ? (
+          <p className="dip-log-empty">None of your units need to retreat.</p>
         ) : (
           <div className="dip-retreat-list">
-            {board.pendingRetreats.map(pending => {
+            {humanPending.map(pending => {
               const options = board.getRetreatOptions(pending.unitLoc);
               const choice = retreatChoices[pending.unitLoc] || 'DISBAND';
               return (
@@ -596,57 +726,73 @@ export default function DiplomacyGame() {
             })}
           </div>
         )}
-        <button className="dip-primary-btn mt-4 w-full" onClick={submitRetreats}>Submit Retreats</button>
+        <button className="dip-primary-btn mt-4 w-full" onClick={submitRetreats} disabled={turn.isBusy}>
+          {turn.isBusy ? 'Resolving…' : 'Submit Retreats'}
+        </button>
       </div>
     );
   }
 
   function renderWinterPanel() {
+    const adj = adjustments[humanPower];
+    const needsAdjust = adj && (adj.buildCount > 0 || adj.disbandCount > 0);
     return (
       <div className="dip-panel p-4">
         <div className="dip-panel-label mb-2">Winter Adjustments</div>
-        <div className="dip-winter-list">
-          {POWERS.map(power => {
-            const adj = adjustments[power];
-            if (!adj || (adj.buildCount === 0 && adj.disbandCount === 0)) return null;
-            const legal = board.getLegalAdjustmentOrders(power);
-            const selected = buildOrders[power] || [];
-            const need = adj.delta > 0 ? `build ${adj.buildCount}` : `disband ${adj.disbandCount}`;
-            return (
-              <div key={power} className="dip-winter-power">
-                <div className="dip-retreat-head">
-                  <span className="dip-score-swatch" style={{ backgroundColor: POWER_COLORS[power] }} aria-hidden="true" />
-                  {POWER_SHORT_NAMES[power]} — {need}
+        {!needsAdjust ? (
+          <p className="dip-log-empty">You have no builds or disbands this winter.</p>
+        ) : (
+          <div className="dip-winter-list">
+            {(() => {
+              const legal = board.getLegalAdjustmentOrders(humanPower);
+              const selected = buildOrders[humanPower] || [];
+              const need = adj.delta > 0 ? `build ${adj.buildCount}` : `disband ${adj.disbandCount}`;
+              return (
+                <div className="dip-winter-power">
+                  <div className="dip-retreat-head">
+                    <span className="dip-score-swatch" style={{ backgroundColor: POWER_COLORS[humanPower] }} aria-hidden="true" />
+                    {POWER_SHORT_NAMES[humanPower]} — {need}
+                  </div>
+                  <div className="dip-target-grid mt-2">
+                    {legal.map(order => {
+                      const isOn = selected.some(o => pendingKey(o) === pendingKey(order));
+                      const label = order.type === 'build'
+                        ? `+ ${formatUnitType(order.unitType)} ${provinceLabel(order.loc)}`
+                        : `− ${provinceLabel(order.unitLoc)}`;
+                      return (
+                        <button
+                          key={pendingKey(order)}
+                          className={`dip-target-btn ${isOn ? 'active' : ''}`}
+                          onClick={() => toggleBuildOrder(humanPower, order)}
+                        >
+                          {label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <p className="dip-winter-count">{selected.length} selected</p>
                 </div>
-                <div className="dip-target-grid mt-2">
-                  {legal.map(order => {
-                    const isOn = selected.some(o => pendingKey(o) === pendingKey(order));
-                    const label = order.type === 'build'
-                      ? `+ ${formatUnitType(order.unitType)} ${provinceLabel(order.loc)}`
-                      : `− ${provinceLabel(order.unitLoc)}`;
-                    return (
-                      <button
-                        key={pendingKey(order)}
-                        className={`dip-target-btn ${isOn ? 'active' : ''}`}
-                        onClick={() => toggleBuildOrder(power, order)}
-                      >
-                        {label}
-                      </button>
-                    );
-                  })}
-                </div>
-                <p className="dip-winter-count">{selected.length} selected</p>
-              </div>
-            );
-          })}
-        </div>
-        <button className="dip-primary-btn mt-4 w-full" onClick={submitAdjustments}>Submit Adjustments</button>
+              );
+            })()}
+          </div>
+        )}
+        <button className="dip-primary-btn mt-4 w-full" onClick={submitAdjustments} disabled={turn.isBusy}>
+          {turn.isBusy ? 'Resolving…' : 'Submit Adjustments'}
+        </button>
       </div>
     );
   }
 }
 
 // ----- small presentational helpers -----
+
+function safeLoad() {
+  try {
+    return loadGame() || false;
+  } catch (_) {
+    return false;
+  }
+}
 
 function ToggleRow({ label, checked, onChange }) {
   return (

--- a/src/games/diplomacy/DiplomacyGame.test.js
+++ b/src/games/diplomacy/DiplomacyGame.test.js
@@ -1,42 +1,89 @@
-// Smoke test for DiplomacyGame — guards against render-time crashes that the
-// pure-logic DiplomacyBoard suite cannot catch (only mounting the component
-// exercises the SVG map, order panel, and effects). The core assertion is that
-// mounting does not throw and the map + key controls render.
+// Smoke + integration tests for DiplomacyGame — guards against render-time
+// crashes that the pure-logic DiplomacyBoard suite cannot catch (only mounting
+// the component exercises the setup screen, SVG map, order panel, and effects).
+// Agents are stubbed (no real key in CI); assertions are structural.
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import DiplomacyGame from './DiplomacyGame';
 
-describe('DiplomacyGame — render smoke', () => {
-  test('mounts without throwing and renders the map + key state', () => {
-    let container;
-    expect(() => {
-      ({ container } = render(
-        <MemoryRouter>
-          <DiplomacyGame />
-        </MemoryRouter>
-      ));
-    }).not.toThrow();
+// Stub the agent layer: no key, empty negotiation, deterministic.
+jest.mock('./agents/negotiator.js', () => ({
+  runNegotiationPhase: jest.fn(async ({ state }) => ({ state, transcripts: {} })),
+}));
 
-    // The SVG map renders.
-    expect(container.querySelector('.dip-board-svg')).toBeTruthy();
-    // Phase banner + scoreboard + order panel rendered for Spring 1901.
-    expect(container.textContent).toContain('Spring 1901 orders');
-    expect(container.textContent).toContain('Supply Centers');
-    expect(container.textContent).toContain('Submit Orders');
+// The worker hook uses import.meta.url (ESM-only) which Jest can't parse; mock it
+// to the unsupported branch so the game uses the main-thread fallback path.
+jest.mock('./hooks/useAIWorker.js', () => ({
+  __esModule: true,
+  default: () => ({ computeOrders: jest.fn(), isSupported: false }),
+}));
+
+beforeEach(() => {
+  // Each test starts with no saved game / settings so the setup gate shows.
+  localStorage.clear();
+  jest.clearAllMocks();
+});
+
+function startNewGame() {
+  // The setup screen shows first; pick defaults and start.
+  fireEvent.click(screen.getByText('Start Game'));
+}
+
+describe('DiplomacyGame — setup gate', () => {
+  test('shows the setup screen on a fresh mount (no saved game)', () => {
+    render(
+      <MemoryRouter>
+        <DiplomacyGame />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Choose your power')).toBeTruthy();
+    expect(screen.getByText('Start Game')).toBeTruthy();
   });
 
-  test('draws all province nodes and starting units', () => {
+  test('starting a game renders the map + key state and order entry', () => {
     const { container } = render(
       <MemoryRouter>
         <DiplomacyGame />
       </MemoryRouter>
     );
-    // Every province in PROVINCES renders a labelled group.
+    startNewGame();
+
+    expect(container.querySelector('.dip-board-svg')).toBeTruthy();
+    expect(container.textContent).toContain('Spring 1901 orders');
+    expect(container.textContent).toContain('Supply Centers');
+    // The negotiation phase opens before order entry.
+    expect(container.textContent).toContain('Proceed to orders');
+  });
+
+  test('draws all province nodes and starting units once a game begins', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <DiplomacyGame />
+      </MemoryRouter>
+    );
+    startNewGame();
     expect(container.querySelectorAll('.dip-province-group').length).toBe(76);
-    // 22 starting units across the seven powers.
     expect(container.querySelectorAll('.dip-unit-group').length).toBe(22);
+  });
+});
+
+describe('DiplomacyGame — negotiation -> orders flow', () => {
+  test('proceeding to orders reveals the order-entry panel', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <DiplomacyGame />
+      </MemoryRouter>
+    );
+    startNewGame();
+
+    fireEvent.click(screen.getByText('Proceed to orders'));
+    await waitFor(() => {
+      expect(container.textContent).toContain('Submit Orders');
+    });
+    // Order entry is scoped to the human power only ("Your Orders").
+    expect(container.textContent).toContain('Your Orders');
   });
 });

--- a/src/games/diplomacy/DiplomacySetup.jsx
+++ b/src/games/diplomacy/DiplomacySetup.jsx
@@ -1,0 +1,116 @@
+// New-game setup for Diplomacy ([Negotiation Loop] PR2).
+//
+// Pick your power, difficulty, persona spice, and the maximum game year, then
+// start. The chosen power becomes the only 'human' controller; the other six are
+// 'AI'. Scoped under .game-diplomacy. Pure presentational + local draft state;
+// the parent owns board creation and persistence.
+
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { POWER_NAMES, POWER_COLORS } from './DiplomacyBoard.js';
+import {
+  POWER_OPTIONS,
+  DIFFICULTY_OPTIONS,
+  DEFAULT_SETTINGS,
+} from './diplomacySettings.js';
+
+const DIFFICULTY_LABELS = { easy: 'Easy', normal: 'Normal', hard: 'Hard' };
+const MAX_YEAR_OPTIONS = [1905, 1910, 1912, 1920];
+
+export default function DiplomacySetup({ initial, onStart }) {
+  const base = { ...DEFAULT_SETTINGS, ...(initial || {}) };
+  const [power, setPower] = useState(base.power);
+  const [difficulty, setDifficulty] = useState(base.difficulty);
+  const [personaSpice, setPersonaSpice] = useState(base.personaSpice);
+  const [maxYears, setMaxYears] = useState(base.maxYears);
+
+  function start() {
+    onStart({ power, difficulty, personaSpice, maxYears });
+  }
+
+  return (
+    <div className="dip-setup">
+      <div className="dip-setup-card">
+        <Link to="/" className="dip-panel-label hover:opacity-80">GIPF Project</Link>
+        <h1 className="mt-1 font-display text-4xl font-bold" style={{ color: 'var(--dip-text)' }}>DIPLOMACY</h1>
+        <p className="dip-setup-subtitle">
+          Negotiate, ally, and betray your way to 18 supply centers against six AI powers.
+        </p>
+
+        <div className="dip-setup-section">
+          <div className="dip-panel-label mb-2">Choose your power</div>
+          <div className="dip-setup-powers">
+            {POWER_OPTIONS.map((p) => (
+              <button
+                key={p}
+                type="button"
+                className={`dip-setup-power${power === p ? ' is-active' : ''}`}
+                style={{ '--power-color': POWER_COLORS[p] }}
+                onClick={() => setPower(p)}
+                aria-pressed={power === p}
+              >
+                <span className="dip-setup-power-swatch" style={{ backgroundColor: POWER_COLORS[p] }} aria-hidden="true" />
+                {POWER_NAMES[p]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="dip-setup-section">
+          <div className="dip-panel-label mb-2">Difficulty</div>
+          <div className="dip-setup-row">
+            {DIFFICULTY_OPTIONS.map((d) => (
+              <button
+                key={d}
+                type="button"
+                className={`dip-setup-pill${difficulty === d ? ' is-active' : ''}`}
+                onClick={() => setDifficulty(d)}
+                aria-pressed={difficulty === d}
+              >
+                {DIFFICULTY_LABELS[d]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="dip-setup-section">
+          <div className="dip-panel-label mb-2">
+            Persona spice <span className="dip-setup-spice-value">{Math.round(personaSpice * 100)}%</span>
+          </div>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.05"
+            value={personaSpice}
+            onChange={(e) => setPersonaSpice(Number(e.target.value))}
+            className="dip-setup-slider"
+            aria-label="Persona spice"
+          />
+          <p className="dip-setup-hint">How dramatically the AI powers play their personalities.</p>
+        </div>
+
+        <div className="dip-setup-section">
+          <div className="dip-panel-label mb-2">Game ends by year</div>
+          <div className="dip-setup-row">
+            {MAX_YEAR_OPTIONS.map((y) => (
+              <button
+                key={y}
+                type="button"
+                className={`dip-setup-pill${maxYears === y ? ' is-active' : ''}`}
+                onClick={() => setMaxYears(y)}
+                aria-pressed={maxYears === y}
+              >
+                {y}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <button type="button" className="dip-primary-btn mt-6 w-full" onClick={start}>
+          Start Game
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/games/diplomacy/DiplomacyTurnLoop.test.js
+++ b/src/games/diplomacy/DiplomacyTurnLoop.test.js
@@ -1,0 +1,240 @@
+// End-to-end turn-loop tests for Diplomacy ([Negotiation Loop] PR1/PR2) with
+// STUBBED agents (Jest module mocks; no real key in CI). Asserts STRUCTURE, never
+// LLM text: a full Spring 1901 turn runs negotiation -> orders -> applyMove true
+// -> results from orderHistory[0]; the no-key path completes a full year via the
+// tactical fallback; difficulty threads the sim budget; and the loop never stalls.
+
+import DiplomacyBoard from './DiplomacyBoard.js';
+import { decideIntents, makeGetOrders } from './hooks/useDiplomacyTurn.js';
+
+// --- module mocks: deterministic, canned agent layer ------------------------
+
+// negotiator.runNegotiationPhase: returns the state unchanged (no AI↔AI text).
+jest.mock('./agents/negotiator.js', () => ({
+  runNegotiationPhase: jest.fn(async ({ state }) => ({ state, transcripts: {} })),
+}));
+
+// agentClient: no key in CI; askAgent yields empty replies.
+jest.mock('./agents/agentClient.js', () => ({
+  askAgent: jest.fn(async () => ({ error: 'no_key', reply: { message: '' } })),
+  hasApiKey: jest.fn(() => false),
+  getApiKey: jest.fn(() => ''),
+  setApiKey: jest.fn(),
+  sendMessage: jest.fn(async () => ({ error: 'no_key', message: '' })),
+  createMemory: jest.requireActual('./agents/memory.js').createMemory,
+  serializeMemory: jest.requireActual('./agents/memory.js').serializeMemory,
+  deserializeMemory: jest.requireActual('./agents/memory.js').deserializeMemory,
+  validateScratchpad: jest.requireActual('./agents/memory.js').validateScratchpad,
+}));
+
+function installLocalStorage() {
+  const store = new Map();
+  Object.defineProperty(global, 'localStorage', {
+    value: {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: (k) => store.delete(k),
+      key: (i) => Array.from(store.keys())[i] ?? null,
+      clear: () => store.clear(),
+      get length() {
+        return store.size;
+      },
+    },
+    configurable: true,
+    writable: true,
+  });
+}
+
+beforeEach(() => {
+  installLocalStorage();
+  jest.clearAllMocks();
+});
+
+// --- the pure order-collection pipeline the hook runs -----------------------
+//
+// We exercise the same code the hook calls (decideIntents + bindOrders via the
+// real aiPlayer getOrders on the main thread, since the worker is unavailable in
+// jsdom) so the test is deterministic and free of React-timer flakiness, while
+// still covering the real intent->orders->applyMove path.
+import { bindOrders, bindRetreats, bindAdjustments, reconcileHonored } from './agents/intentBinding.js';
+import { updateTrustAfterAdjudication } from './agents/trustModel.js';
+import { createDiplomaticState } from './agents/diplomaticState.js';
+
+const CONTROLLERS = {
+  austria: 'AI', england: 'human', france: 'AI', germany: 'AI', italy: 'AI', russia: 'AI', turkey: 'AI',
+};
+const HUMAN = 'england';
+const AI_POWERS = Object.keys(CONTROLLERS).filter((p) => CONTROLLERS[p] === 'AI');
+
+// Resolve a full orders phase: human holds, AI bound via tactical fallback.
+async function resolveOrdersPhase(board, state, difficulty = 'normal') {
+  const getOrders = makeGetOrders({ workerSupported: false, computeOrders: null });
+  const intents = decideIntents(board, state, AI_POWERS);
+  const aiOrders = await bindOrders(board, intents, getOrders, { difficulty });
+
+  const ordersByPower = {};
+  for (const power of board.powers) {
+    if (CONTROLLERS[power] === 'human') {
+      ordersByPower[power] = board.getUnitLocations(power).map((loc) => ({ type: 'hold', unitLoc: loc }));
+    } else {
+      ordersByPower[power] = aiOrders[power] || [];
+    }
+  }
+  const ok = board.applyMove({ type: 'orders', ordersByPower });
+  reconcileHonored(board, intents);
+  const nextState = updateTrustAfterAdjudication(state, board, { actingPowers: Object.keys(intents) });
+  return { ok, nextState };
+}
+
+describe('Diplomacy turn loop — full Spring 1901 with stubbed agents', () => {
+  test('negotiation (no-op) -> orders for all 7 powers -> applyMove true -> results', async () => {
+    const board = new DiplomacyBoard({ maxYears: 1905 });
+    const state = createDiplomaticState({ board, humanPower: HUMAN });
+
+    const { ok } = await resolveOrdersPhase(board, state);
+    expect(ok).toBe(true);
+
+    // Results render off orderHistory[0].
+    const log = board.orderHistory[0];
+    expect(log).toBeTruthy();
+    expect(Object.keys(log.orders).length).toBeGreaterThan(0);
+    // Every starting unit got an order (no power was skipped).
+    const orderedLocs = Object.keys(log.orders);
+    expect(orderedLocs.length).toBe(22);
+  });
+
+  test('AI orders are all legal (survive applyMove) and the human only holds', async () => {
+    const board = new DiplomacyBoard({ maxYears: 1905 });
+    const state = createDiplomaticState({ board, humanPower: HUMAN });
+    const getOrders = makeGetOrders({ workerSupported: false, computeOrders: null });
+    const intents = decideIntents(board, state, AI_POWERS);
+    const aiOrders = await bindOrders(board, intents, getOrders, { difficulty: 'normal' });
+
+    // No AI order set is empty for a power that has units.
+    for (const power of AI_POWERS) {
+      expect(Array.isArray(aiOrders[power])).toBe(true);
+      expect(aiOrders[power].length).toBe(board.getUnitLocations(power).length);
+    }
+    // The human power is never computed by the AI binder.
+    expect(aiOrders[HUMAN]).toBeUndefined();
+  });
+});
+
+describe('Diplomacy turn loop — retreats and winter', () => {
+  test('a dislodgement opens a retreat phase that AI binding resolves', async () => {
+    // Hand-build a dislodgement: Austria BUD+TRI dislodge Turkey SER.
+    const board = new DiplomacyBoard({ maxYears: 1905 });
+    board.units = {
+      BUD: { power: 'austria', type: 'army' },
+      TRI: { power: 'austria', type: 'army' },
+      SER: { power: 'turkey', type: 'army' },
+    };
+    board.phase = 'spring-orders';
+    board.season = 'spring';
+
+    const ordersByPower = {
+      austria: [
+        { type: 'move', unitLoc: 'BUD', to: 'SER' },
+        { type: 'support-move', unitLoc: 'TRI', from: 'BUD', to: 'SER' },
+      ],
+      turkey: [{ type: 'hold', unitLoc: 'SER' }],
+    };
+    expect(board.applyMove({ type: 'orders', ordersByPower })).toBe(true);
+    expect(board.isRetreatPhase()).toBe(true);
+    expect(board.pendingRetreats.length).toBe(1);
+
+    const state = createDiplomaticState({ board, humanPower: HUMAN });
+    const getOrders = makeGetOrders({ workerSupported: false, computeOrders: null });
+    const intents = decideIntents(board, state, ['turkey']);
+    const retreatsByPower = await bindRetreats(board, { turkey: intents.turkey || null }, getOrders, {});
+    expect(board.applyMove({ type: 'retreats', retreatsByPower })).toBe(true);
+    expect(board.isRetreatPhase()).toBe(false);
+  });
+
+  test('winter builds/disbands resolve via bindAdjustments', async () => {
+    const board = new DiplomacyBoard({ maxYears: 1905 });
+    // Force a winter phase with a build available for Austria.
+    board.units = { VIE: { power: 'austria', type: 'army' } };
+    board.supplyCenters = { VIE: 'austria', BUD: 'austria', TRI: 'austria' };
+    board.phase = 'winter-build';
+    board.season = 'fall';
+
+    const adj = board.getAdjustments().austria;
+    expect(adj.buildCount).toBeGreaterThan(0);
+
+    const state = createDiplomaticState({ board, humanPower: HUMAN });
+    const getOrders = makeGetOrders({ workerSupported: false, computeOrders: null });
+    const intents = decideIntents(board, state, ['austria']);
+    const adjustmentsByPower = await bindAdjustments(board, { austria: intents.austria || null }, getOrders, {});
+    expect(board.applyMove({ type: 'adjustments', adjustmentsByPower })).toBe(true);
+    // Winter resolved -> back to a new orders phase.
+    expect(board.isOrdersPhase()).toBe(true);
+  });
+});
+
+describe('Diplomacy turn loop — graceful degradation', () => {
+  test('no key: a full year (Spring + Fall) completes via tactical fallback', async () => {
+    const board = new DiplomacyBoard({ maxYears: 1905 });
+    let state = createDiplomaticState({ board, humanPower: HUMAN });
+
+    let phasesResolved = 0;
+    let guard = 0;
+    // Drive the loop until we reach (at least) the next year's Spring orders.
+    const startYear = board.year;
+    while (guard++ < 12 && board.phase !== 'game-over') {
+      if (board.isOrdersPhase()) {
+        const res = await resolveOrdersPhase(board, state);
+        expect(res.ok).toBe(true);
+        state = res.nextState;
+        phasesResolved += 1;
+      } else if (board.isRetreatPhase()) {
+        const getOrders = makeGetOrders({ workerSupported: false, computeOrders: null });
+        const intents = decideIntents(board, state, AI_POWERS);
+        const retreatsByPower = await bindRetreats(board, intents, getOrders, {});
+        expect(board.applyMove({ type: 'retreats', retreatsByPower })).toBe(true);
+      } else if (board.isWinterPhase()) {
+        const getOrders = makeGetOrders({ workerSupported: false, computeOrders: null });
+        const intents = decideIntents(board, state, AI_POWERS);
+        const adjustmentsByPower = await bindAdjustments(board, intents, getOrders, {});
+        expect(board.applyMove({ type: 'adjustments', adjustmentsByPower })).toBe(true);
+      }
+      if (board.year > startYear) break;
+    }
+    // At least the two orders phases (Spring + Fall) of the first year resolved.
+    expect(phasesResolved).toBeGreaterThanOrEqual(2);
+    expect(board.year).toBeGreaterThanOrEqual(startYear + 1);
+  });
+
+  test('an AI getOrders that throws falls back to holds; the phase still completes', async () => {
+    const board = new DiplomacyBoard({ maxYears: 1905 });
+    const state = createDiplomaticState({ board, humanPower: HUMAN });
+    const throwingGetOrders = jest.fn(async () => {
+      throw new Error('simulated AI failure');
+    });
+    const intents = decideIntents(board, state, AI_POWERS);
+    const aiOrders = await bindOrders(board, intents, throwingGetOrders, { difficulty: 'normal' });
+
+    // Every AI power still has a (hold) order set; nothing empty.
+    for (const power of AI_POWERS) {
+      expect(aiOrders[power].length).toBe(board.getUnitLocations(power).length);
+      expect(aiOrders[power].every((o) => o.type === 'hold')).toBe(true);
+    }
+    const ordersByPower = { ...aiOrders };
+    ordersByPower[HUMAN] = board.getUnitLocations(HUMAN).map((loc) => ({ type: 'hold', unitLoc: loc }));
+    expect(board.applyMove({ type: 'orders', ordersByPower })).toBe(true);
+  });
+});
+
+describe('Diplomacy turn loop — difficulty budget', () => {
+  test('difficulty is threaded into getOrders options', async () => {
+    const board = new DiplomacyBoard({ maxYears: 1905 });
+    const state = createDiplomaticState({ board, humanPower: HUMAN });
+    const spy = jest.fn(async (b, power) => ({ orders: b.getUnitLocations(power).map((loc) => ({ type: 'hold', unitLoc: loc })) }));
+    const intents = decideIntents(board, state, AI_POWERS);
+    await bindOrders(board, intents, spy, { difficulty: 'hard' });
+
+    // Some call carried difficulty:'hard'.
+    const sawHard = spy.mock.calls.some((args) => args[2] && args[2].difficulty === 'hard');
+    expect(sawHard).toBe(true);
+  });
+});

--- a/src/games/diplomacy/diplomacy.css
+++ b/src/games/diplomacy/diplomacy.css
@@ -619,3 +619,151 @@
   from { opacity: 0; }
   to { opacity: 0.85; }
 }
+
+/* ========== Setup screen ([Negotiation Loop] PR2) ========== */
+
+.game-diplomacy .dip-setup {
+  display: flex;
+  min-height: 100vh;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.game-diplomacy .dip-setup-card {
+  width: 100%;
+  max-width: 560px;
+  border: 1px solid var(--dip-border);
+  background: var(--dip-panel);
+  border-radius: 18px;
+  padding: 1.75rem;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.12);
+}
+
+.game-diplomacy .dip-setup-subtitle {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--dip-text-muted);
+}
+
+.game-diplomacy .dip-setup-section {
+  margin-top: 1.5rem;
+}
+
+.game-diplomacy .dip-setup-powers {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.5rem;
+}
+
+.game-diplomacy .dip-setup-power {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--dip-border);
+  border-radius: 10px;
+  background: var(--dip-soft);
+  color: var(--dip-text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-align: left;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.game-diplomacy .dip-setup-power:hover {
+  border-color: var(--dip-border-strong);
+}
+
+.game-diplomacy .dip-setup-power.is-active {
+  border-color: var(--power-color);
+  box-shadow: 0 0 0 2px var(--power-color) inset;
+}
+
+.game-diplomacy .dip-setup-power-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.game-diplomacy .dip-setup-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.game-diplomacy .dip-setup-pill {
+  padding: 0.45rem 1rem;
+  border: 1px solid var(--dip-border);
+  border-radius: 999px;
+  background: var(--dip-soft);
+  color: var(--dip-text);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.game-diplomacy .dip-setup-pill.is-active {
+  border-color: var(--dip-accent);
+  background: var(--dip-accent);
+  color: var(--dip-btn-primary-text);
+}
+
+.game-diplomacy .dip-setup-slider {
+  width: 100%;
+  accent-color: var(--dip-accent);
+}
+
+.game-diplomacy .dip-setup-spice-value {
+  color: var(--dip-text-muted);
+  font-weight: 600;
+}
+
+.game-diplomacy .dip-setup-hint {
+  margin-top: 0.4rem;
+  font-size: 0.78rem;
+  color: var(--dip-text-muted);
+}
+
+/* ========== Turn-loop status + fallback prompt ========== */
+
+.game-diplomacy .dip-you-line {
+  font-size: 0.82rem;
+  color: var(--dip-text-muted);
+}
+
+.game-diplomacy .dip-progress {
+  font-size: 0.82rem;
+  color: var(--dip-accent);
+  font-weight: 600;
+  animation: diplomacy-fade-in 0.6s ease both;
+}
+
+.game-diplomacy .dip-score-row.is-you {
+  outline: 1px dashed var(--dip-border-strong);
+  outline-offset: -1px;
+  border-radius: 6px;
+}
+
+.game-diplomacy .dip-keyprompt {
+  border: 1px solid var(--dip-border);
+  background: var(--dip-soft);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.game-diplomacy .dip-keyprompt-text {
+  font-size: 0.8rem;
+  line-height: 1.45;
+  color: var(--dip-text-muted);
+}
+
+.game-diplomacy .dip-keyprompt-dismiss {
+  align-self: flex-end;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--dip-accent);
+}

--- a/src/games/diplomacy/diplomacyPersistence.js
+++ b/src/games/diplomacy/diplomacyPersistence.js
@@ -1,0 +1,192 @@
+// Full versioned game persistence for Diplomacy ([Negotiation Loop] PR3).
+//
+// ONE versioned save object lives under the `diplomacyGameState` localStorage
+// key. It carries the board snapshot, the UI phase, per-power controllers,
+// personas, the HUMAN-VISIBLE conversations, and the HIDDEN AI↔AI diplomatic
+// state. The visible and hidden stores are kept strictly separate — AI↔AI text
+// is never rendered, and the loader/saver never moves one into the other.
+//
+// All access is guarded: JSON parse/stringify in try/catch; an over-cap save is
+// trimmed (oldest conversation turns dropped first); a QuotaExceededError is
+// caught and the save degrades (trim then retry) rather than throwing; corrupt
+// or wrong-version data loads as null so the app starts fresh. Pure of React.
+
+const SAVE_KEY = 'diplomacyGameState';
+export const SAVE_VERSION = 1;
+
+// Soft byte cap for the serialized save. Above this we trim conversation turns
+// (oldest first) before writing. Generous — a full game's board + state is small;
+// conversations are the only unbounded growth, and they degrade gracefully.
+const BYTE_CAP = 400_000;
+
+// Keep at least this many of the most-recent turns per conversation thread even
+// when trimming, so a reload never loses the live exchange.
+const MIN_TURNS_PER_THREAD = 4;
+
+// Approximate UTF-8 byte length of a string (good enough for a soft cap).
+function byteLength(str) {
+  try {
+    return new Blob([str]).size;
+  } catch (_) {
+    // Blob unavailable (older test envs): fall back to char length.
+    return str.length;
+  }
+}
+
+// Deep clone via JSON so trimming never mutates the caller's live stores.
+function jsonClone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+// Trim the oldest messages from each conversation thread, keeping the most
+// recent `keepPerThread`. Returns a new conversations object (input untouched).
+function trimConversations(conversations, keepPerThread) {
+  if (!conversations || typeof conversations !== 'object') return conversations;
+  const threads = conversations.threads;
+  if (!threads || typeof threads !== 'object') return conversations;
+  const out = { ...conversations, threads: {} };
+  for (const [power, thread] of Object.entries(threads)) {
+    if (thread && Array.isArray(thread.messages) && thread.messages.length > keepPerThread) {
+      out.threads[power] = {
+        ...thread,
+        messages: thread.messages.slice(thread.messages.length - keepPerThread),
+      };
+    } else {
+      out.threads[power] = thread;
+    }
+  }
+  return out;
+}
+
+// Build the versioned envelope. `state` is the live, in-memory game state.
+function buildEnvelope(state) {
+  return {
+    version: SAVE_VERSION,
+    savedAt: Date.now(),
+    board: state.board && typeof state.board.serializeState === 'function'
+      ? state.board.serializeState()
+      : state.board,
+    uiPhase: state.uiPhase,
+    controllers: state.controllers || null,
+    personas: state.personas || null,
+    // Human-VISIBLE thread store only.
+    conversations: state.conversations || null,
+    // Hidden AI↔AI diplomatic state — persisted but never rendered.
+    diplomaticState: state.diplomaticState || null,
+  };
+}
+
+// Serialize an envelope, trimming conversations until it fits under the byte cap
+// (down to a floor) so an oversized history can't block a save.
+function serializeWithinCap(envelope) {
+  let payload = JSON.stringify(envelope);
+  if (byteLength(payload) <= BYTE_CAP) return { payload, envelope };
+
+  let keep = 24; // start generous, shrink toward the floor
+  let trimmed = envelope;
+  while (keep >= MIN_TURNS_PER_THREAD) {
+    trimmed = { ...envelope, conversations: trimConversations(envelope.conversations, keep) };
+    payload = JSON.stringify(trimmed);
+    if (byteLength(payload) <= BYTE_CAP) break;
+    keep = Math.floor(keep / 2);
+  }
+  return { payload, envelope: trimmed };
+}
+
+// saveGame(state) — persist the whole game. Never throws.
+//   state = { board, uiPhase, controllers, personas, conversations, diplomaticState }
+// `board` may be a live DiplomacyBoard (serialized here) or an already-serialized
+// snapshot. Returns true on success, false if the write degraded/failed.
+export function saveGame(state) {
+  if (!state) return false;
+  let envelope;
+  try {
+    envelope = buildEnvelope(state);
+  } catch (_) {
+    return false;
+  }
+
+  try {
+    const { payload } = serializeWithinCap(envelope);
+    try {
+      localStorage.setItem(SAVE_KEY, payload);
+      return true;
+    } catch (err) {
+      if (!isQuotaError(err)) return false;
+      // Quota: trim hard to the floor and retry once. Never throw.
+      try {
+        const trimmed = { ...envelope, conversations: trimConversations(envelope.conversations, MIN_TURNS_PER_THREAD) };
+        localStorage.setItem(SAVE_KEY, JSON.stringify(trimmed));
+        return true;
+      } catch (_) {
+        return false; // give up silently
+      }
+    }
+  } catch (_) {
+    return false;
+  }
+}
+
+function isQuotaError(err) {
+  return (
+    err &&
+    (err.name === 'QuotaExceededError' ||
+      err.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+      err.code === 22 ||
+      err.code === 1014)
+  );
+}
+
+// loadGame() — read and validate the saved game. Returns the envelope (a plain
+// object with `board` as a serialized snapshot) or null when there is no save,
+// the JSON is corrupt, or the version is unknown. Never throws.
+export function loadGame() {
+  let raw;
+  try {
+    raw = localStorage.getItem(SAVE_KEY);
+  } catch (_) {
+    return null;
+  }
+  if (!raw) return null;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (_) {
+    return null; // corrupt JSON
+  }
+
+  if (!parsed || typeof parsed !== 'object') return null;
+  if (parsed.version !== SAVE_VERSION) return null; // unknown / old version
+  if (!parsed.board || typeof parsed.board !== 'object') return null; // partial
+
+  return {
+    version: parsed.version,
+    savedAt: parsed.savedAt || null,
+    board: parsed.board,
+    uiPhase: parsed.uiPhase || 'negotiation',
+    controllers: parsed.controllers || null,
+    personas: parsed.personas || null,
+    conversations: parsed.conversations || null,
+    diplomaticState: parsed.diplomaticState || null,
+  };
+}
+
+// clearGame() — remove the saved game AND every diplomacy*-prefixed key except
+// the shared cross-game `gipfApiKey` (which belongs to the whole app, not this
+// game). Never throws.
+export function clearGame() {
+  try {
+    const keys = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith('diplomacy')) keys.push(key);
+    }
+    for (const key of keys) localStorage.removeItem(key);
+  } catch (_) {
+    /* ignore storage failures */
+  }
+}
+
+// Exported for tests.
+export { trimConversations, jsonClone, BYTE_CAP, MIN_TURNS_PER_THREAD };

--- a/src/games/diplomacy/diplomacyPersistence.test.js
+++ b/src/games/diplomacy/diplomacyPersistence.test.js
@@ -1,0 +1,184 @@
+// Tests for full versioned persistence ([Negotiation Loop] PR3). Structural
+// assertions only — round-trip equality, corruption/quota guards, key clearing,
+// and the strict visible/hidden separation that keeps AI↔AI text out of the
+// human-visible conversation store.
+
+import DiplomacyBoard from './DiplomacyBoard.js';
+import { saveGame, loadGame, clearGame, SAVE_VERSION } from './diplomacyPersistence.js';
+
+// A minimal jsdom-style localStorage if the test env lacks one.
+function installLocalStorage() {
+  const store = new Map();
+  const ls = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    clear: () => store.clear(),
+    get length() {
+      return store.size;
+    },
+  };
+  Object.defineProperty(global, 'localStorage', { value: ls, configurable: true, writable: true });
+  return ls;
+}
+
+beforeEach(() => {
+  installLocalStorage();
+});
+
+const SENTINEL = 'AI_TO_AI_SECRET_DO_NOT_SHOW_HUMAN';
+
+// Build a representative game-state snapshot for persistence.
+function makeState({ board, uiPhase = 'negotiation' } = {}) {
+  const b = board || new DiplomacyBoard({ maxYears: 1905 });
+  return {
+    board: b,
+    uiPhase,
+    controllers: { austria: 'AI', england: 'human', france: 'AI', germany: 'AI', italy: 'AI', russia: 'AI', turkey: 'AI' },
+    personas: { france: { name: 'France', temperament: { trust: 0.5 } } },
+    conversations: {
+      threads: {
+        france: { power: 'france', messages: [{ role: 'user', content: 'hello', turn: 'Spring 1901' }], scratchpad: null, updatedAt: 1 },
+      },
+    },
+    diplomaticState: {
+      version: 1,
+      humanPower: 'england',
+      relations: {},
+      agreements: [],
+      promises: [],
+      promiseLedger: {},
+      // hidden AI↔AI transcript content carrying the sentinel.
+      transcripts: { 'austria~france': [{ round: 0, power: 'austria', message: SENTINEL }] },
+    },
+  };
+}
+
+describe('diplomacyPersistence — round trip', () => {
+  test('saveGame then loadGame restores the envelope fields', () => {
+    const state = makeState();
+    expect(saveGame(state)).toBe(true);
+
+    const loaded = loadGame();
+    expect(loaded).toBeTruthy();
+    expect(loaded.version).toBe(SAVE_VERSION);
+    expect(loaded.uiPhase).toBe('negotiation');
+    expect(loaded.controllers.england).toBe('human');
+    expect(loaded.personas.france.name).toBe('France');
+    expect(loaded.conversations.threads.france.messages[0].content).toBe('hello');
+    expect(loaded.diplomaticState.humanPower).toBe('england');
+  });
+
+  test('board snapshot reloads to an equal board snapshot', () => {
+    const board = new DiplomacyBoard({ maxYears: 1905 });
+    saveGame(makeState({ board }));
+    const loaded = loadGame();
+    const restored = DiplomacyBoard.fromSerializedState(loaded.board);
+    // Deep equality of the canonical snapshot (ignoring undo history noise).
+    const a = board.serializeState();
+    const b = restored.serializeState();
+    expect(b.units).toEqual(a.units);
+    expect(b.supplyCenters).toEqual(a.supplyCenters);
+    expect(b.phase).toBe(a.phase);
+    expect(b.year).toBe(a.year);
+    expect(b.maxYears).toBe(a.maxYears);
+  });
+
+  test('reload is identical for each UI phase (deep equality)', () => {
+    for (const uiPhase of ['negotiation', 'orders', 'retreats', 'winter']) {
+      installLocalStorage();
+      const state = makeState({ uiPhase });
+      saveGame(state);
+      const loaded = loadGame();
+      expect(loaded.uiPhase).toBe(uiPhase);
+      expect(loaded.conversations).toEqual(state.conversations);
+      expect(loaded.diplomaticState).toEqual(state.diplomaticState);
+      expect(loaded.controllers).toEqual(state.controllers);
+      expect(loaded.personas).toEqual(state.personas);
+    }
+  });
+});
+
+describe('diplomacyPersistence — guards', () => {
+  test('saveGame never throws when setItem throws QuotaExceededError', () => {
+    const state = makeState();
+    const err = new Error('quota');
+    err.name = 'QuotaExceededError';
+    let calls = 0;
+    localStorage.setItem = () => {
+      calls += 1;
+      throw err;
+    };
+    expect(() => saveGame(state)).not.toThrow();
+    // It attempted to write (and the retry also threw) — never propagated.
+    expect(calls).toBeGreaterThanOrEqual(1);
+  });
+
+  test('saveGame trims oldest conversation turns over the byte cap', () => {
+    const board = new DiplomacyBoard({ maxYears: 1905 });
+    const big = [];
+    for (let i = 0; i < 5000; i++) big.push({ role: 'user', content: `msg-${i}-`.repeat(40), turn: 'Spring 1901' });
+    const state = makeState({ board });
+    state.conversations.threads.france.messages = big;
+
+    expect(saveGame(state)).toBe(true);
+    const loaded = loadGame();
+    // Trimmed to a small recent slice — far fewer than 5000.
+    expect(loaded.conversations.threads.france.messages.length).toBeLessThan(5000);
+    expect(loaded.conversations.threads.france.messages.length).toBeGreaterThan(0);
+    // The most-recent message survives.
+    const last = loaded.conversations.threads.france.messages.slice(-1)[0];
+    expect(last.content).toContain('msg-4999');
+  });
+
+  test('loadGame returns null for corrupt JSON', () => {
+    localStorage.setItem('diplomacyGameState', '{not valid json');
+    expect(loadGame()).toBeNull();
+  });
+
+  test('loadGame returns null for an unknown version', () => {
+    localStorage.setItem('diplomacyGameState', JSON.stringify({ version: 999, board: {} }));
+    expect(loadGame()).toBeNull();
+  });
+
+  test('loadGame returns null for a partial object missing the board', () => {
+    localStorage.setItem('diplomacyGameState', JSON.stringify({ version: SAVE_VERSION, uiPhase: 'orders' }));
+    expect(loadGame()).toBeNull();
+  });
+
+  test('loadGame returns null when no save exists', () => {
+    expect(loadGame()).toBeNull();
+  });
+});
+
+describe('diplomacyPersistence — clearGame', () => {
+  test('removes every diplomacy*-prefixed key', () => {
+    saveGame(makeState());
+    localStorage.setItem('diplomacySettings', '{}');
+    localStorage.setItem('diplomacyDarkMode', 'true');
+    localStorage.setItem('gipfApiKey', 'sk-keep-me');
+
+    clearGame();
+
+    const remaining = [];
+    for (let i = 0; i < localStorage.length; i++) remaining.push(localStorage.key(i));
+    expect(remaining.filter((k) => k && k.startsWith('diplomacy'))).toHaveLength(0);
+    // The shared cross-game key is NOT a diplomacy key, so it survives.
+    expect(localStorage.getItem('gipfApiKey')).toBe('sk-keep-me');
+  });
+});
+
+describe('diplomacyPersistence — visible/hidden separation', () => {
+  test('AI↔AI sentinel never appears in the human-visible conversations after reload', () => {
+    const state = makeState();
+    saveGame(state);
+    const loaded = loadGame();
+
+    const visible = JSON.stringify(loaded.conversations);
+    expect(visible).not.toContain(SENTINEL);
+    // It IS retained in the hidden diplomatic state (persisted, never rendered).
+    const hidden = JSON.stringify(loaded.diplomaticState);
+    expect(hidden).toContain(SENTINEL);
+  });
+});

--- a/src/games/diplomacy/diplomacySettings.js
+++ b/src/games/diplomacy/diplomacySettings.js
@@ -1,0 +1,91 @@
+// New-game setup settings for Diplomacy ([Negotiation Loop] PR2).
+//
+// Read/write the chosen power, difficulty, persona spice, and maxYears under the
+// single `diplomacySettings` localStorage key. This is its OWN copy of the
+// settings-helper style — no cross-game import (each game keeps its conventions
+// independent). Pure of React; safe against storage failures and corrupt JSON.
+
+const SETTINGS_KEY = 'diplomacySettings';
+
+export const POWER_OPTIONS = [
+  'austria',
+  'england',
+  'france',
+  'germany',
+  'italy',
+  'russia',
+  'turkey',
+];
+
+export const DIFFICULTY_OPTIONS = ['easy', 'normal', 'hard'];
+
+// Difficulty -> sim budget passed to the AI order computation (threaded into the
+// worker/hook `options`). The tactical engine reads `difficulty`; we also surface
+// a numeric `sims` knob so a tier change is verifiable independently of the
+// engine's internal budget table.
+export const DIFFICULTY_BUDGET = {
+  easy: { difficulty: 'easy', sims: 40 },
+  normal: { difficulty: 'normal', sims: 120 },
+  hard: { difficulty: 'hard', sims: 240 },
+};
+
+export function budgetForDifficulty(difficulty) {
+  return DIFFICULTY_BUDGET[difficulty] || DIFFICULTY_BUDGET.normal;
+}
+
+export const DEFAULT_SETTINGS = {
+  power: 'england',
+  difficulty: 'normal',
+  // personaSpice biases how flavourful the personas play (0 = plain, 1 = spicy).
+  personaSpice: 0.5,
+  maxYears: 1912,
+};
+
+function clampSpice(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return DEFAULT_SETTINGS.personaSpice;
+  return Math.max(0, Math.min(1, n));
+}
+
+function sanitize(raw) {
+  const settings = { ...DEFAULT_SETTINGS };
+  if (raw && typeof raw === 'object') {
+    if (POWER_OPTIONS.includes(raw.power)) settings.power = raw.power;
+    if (DIFFICULTY_OPTIONS.includes(raw.difficulty)) settings.difficulty = raw.difficulty;
+    if (raw.personaSpice != null) settings.personaSpice = clampSpice(raw.personaSpice);
+    const years = Number(raw.maxYears);
+    if (Number.isInteger(years) && years >= 1901 && years <= 2000) settings.maxYears = years;
+  }
+  return settings;
+}
+
+// Read the persisted settings, falling back to defaults for any missing or
+// invalid field. Never throws.
+export function loadSettings() {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) return { ...DEFAULT_SETTINGS };
+    return sanitize(JSON.parse(raw));
+  } catch (_) {
+    return { ...DEFAULT_SETTINGS };
+  }
+}
+
+// Persist a (sanitized) settings object. Never throws.
+export function saveSettings(settings) {
+  try {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(sanitize(settings)));
+  } catch (_) {
+    /* ignore storage failures */
+  }
+}
+
+// Build the per-power controller config from the chosen human power: the chosen
+// power is 'human', the other six are 'AI'.
+export function buildControllers(humanPower) {
+  const controllers = {};
+  for (const power of POWER_OPTIONS) {
+    controllers[power] = power === humanPower ? 'human' : 'AI';
+  }
+  return controllers;
+}

--- a/src/games/diplomacy/hooks/useDiplomacyTurn.js
+++ b/src/games/diplomacy/hooks/useDiplomacyTurn.js
@@ -1,0 +1,409 @@
+// Turn controller for Diplomacy ([Negotiation Loop] PR1).
+//
+// A UI-level state machine that ties every prior piece into one playable loop:
+//
+//   negotiation -> orders -> resolving -> retreats -> winter -> (next) negotiation
+//
+// The NEGOTIATION phase is UI-only (it precedes each engine *-orders phase and is
+// NOT an engine phase — DiplomacyBoard.js is never modified). During negotiation
+// the human chats with any AI power (ChatPanel) and the AI↔AI orchestrator
+// (runNegotiationPhase) runs its bounded private rounds, evolving the hidden
+// diplomatic state. "Proceed to orders" advances; the human then enters only
+// their own power's orders while AI powers' orders are computed via
+// intentBinding.bindOrders using betrayalModel.decideStrategicIntent per AI power
+// plus the tactical getOrders (off-thread via the worker where available, with a
+// main-thread fallback). After adjudication the honored/broken signal is fed to
+// the trust model exactly once.
+//
+// Mirrors Catan's AI-loop discipline: an `isBusy` ref guards re-entrancy, async
+// work is wrapped so no rejection ever breaks the turn, and every phase has a
+// deterministic exit (full no-key / all-failure fallback to no-intent tactical
+// orders -> hold). Never stalls; never emits illegal orders (intentBinding only
+// returns orders that survive the engine's sanitizer for the acting power).
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import DiplomacyBoard from '../DiplomacyBoard.js';
+import * as aiPlayer from '../engine/aiPlayer.js';
+import { decideStrategicIntent } from '../agents/betrayalModel.js';
+import { bindOrders, bindRetreats, bindAdjustments, reconcileHonored } from '../agents/intentBinding.js';
+import { updateTrustAfterAdjudication } from '../agents/trustModel.js';
+import { runNegotiationPhase } from '../agents/negotiator.js';
+import { askAgent, hasApiKey } from '../agents/agentClient.js';
+import { serializeBoardContext } from '../agents/serializeContext.js';
+
+// Hard caps so a phase always terminates even if every AI call hangs/fails.
+const NEGOTIATION_OPTIONS = { maxRounds: 2, maxPairsPerRound: 4 };
+
+// AI powers in the controller config (everything not 'human').
+function aiPowersOf(controllers, board) {
+  const alive = new Set(board.getPowerIds());
+  return Object.keys(controllers || {})
+    .filter((p) => controllers[p] === 'AI' && alive.has(p));
+}
+
+// Build the strategic intents for every AI power from the hidden diplomatic
+// state. Pure + synchronous; a thrown decision never aborts the loop.
+function decideIntents(board, diplomaticState, aiPowers) {
+  const intents = {};
+  for (const power of aiPowers) {
+    try {
+      intents[power] = decideStrategicIntent({ board, state: diplomaticState, power });
+    } catch (_) {
+      intents[power] = null; // no-intent fallback for this power
+    }
+  }
+  return intents;
+}
+
+// A `getOrders(board, power, options)` adapter for intentBinding that runs the
+// tactical search off-thread via the worker when supported, falling back to the
+// main-thread engine. Worker calls are serialized (one in-flight callback) and
+// each carries that power's own `options` (intent + difficulty), so per-power
+// intent is honored even off-thread.
+function makeGetOrders({ workerSupported, computeOrders }) {
+  return function getOrders(board, power, options = {}) {
+    if (workerSupported && computeOrders) {
+      return new Promise((resolve) => {
+        let settled = false;
+        const finish = (orders) => {
+          if (settled) return;
+          settled = true;
+          resolve({ orders: orders || [] });
+        };
+        try {
+          computeOrders(
+            board.serializeState(),
+            [power],
+            options,
+            (data) => finish((data && data.byPower && data.byPower[power]) || []),
+            // On worker error fall back to the main-thread engine.
+            () => {
+              aiPlayer.getOrders(board, power, options).then(finish).catch(() => finish([]));
+            }
+          );
+        } catch (_) {
+          aiPlayer.getOrders(board, power, options).then(finish).catch(() => finish([]));
+        }
+      });
+    }
+    return aiPlayer.getOrders(board, power, options);
+  };
+}
+
+export default function useDiplomacyTurn({
+  board,
+  setBoard,
+  controllers,
+  humanPower,
+  difficultyBudget,
+  diplomaticState,
+  setDiplomaticState,
+  personas,
+  conversations,
+  workerSupported,
+  computeOrders,
+  onPhaseSettled,
+}) {
+  // The UI phase machine. Engine phases (orders/retreats/winter) are reflected
+  // from board.phase; 'negotiation' and 'resolving' are pure UI states.
+  const [uiPhase, setUiPhase] = useState('negotiation');
+  const [isBusy, setIsBusy] = useState(false);
+  const [progress, setProgress] = useState('');
+  const busyRef = useRef(false); // re-entrancy guard (mirrors Catan's isAiThinking)
+
+  // Strategic intents for the AI powers this orders phase. Captured when orders
+  // are computed and re-used by reconcileHonored after adjudication.
+  const intentsRef = useRef(null);
+
+  const getOrders = useCallback(
+    () => makeGetOrders({ workerSupported, computeOrders }),
+    [workerSupported, computeOrders]
+  );
+
+  // Whenever the engine lands on a *-orders phase that the UI machine hasn't yet
+  // gated behind negotiation, drop back into negotiation first.
+  useEffect(() => {
+    if (board.phase === 'game-over') {
+      setUiPhase('game-over');
+      return;
+    }
+    if (board.isRetreatPhase()) {
+      setUiPhase('retreats');
+    } else if (board.isWinterPhase()) {
+      setUiPhase('winter');
+    }
+    // Orders/negotiation transitions are driven explicitly by the controls below,
+    // not by this effect, so a manual "Proceed to orders" isn't undone.
+  }, [board.phase, board]); // board identity changes on every clone()
+
+  const settle = useCallback(
+    (nextUiPhase, nextState) => {
+      if (onPhaseSettled) {
+        onPhaseSettled({
+          uiPhase: nextUiPhase,
+          diplomaticState: nextState !== undefined ? nextState : diplomaticState,
+        });
+      }
+    },
+    [onPhaseSettled, diplomaticState]
+  );
+
+  // ----- negotiation phase -----
+
+  // Run the bounded AI↔AI negotiation, evolving the hidden diplomatic state. With
+  // no key the orchestrator still runs (askAgent returns empty replies, so no
+  // AI↔AI content is produced) — the loop always completes.
+  const runNegotiation = useCallback(async () => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setIsBusy(true);
+    setProgress('The powers are conferring…');
+
+    let nextState = diplomaticState;
+    try {
+      const agents = {};
+      const aiPowers = aiPowersOf(controllers, board);
+      for (const power of aiPowers) {
+        agents[power] = {
+          persona: personas ? personas[power] : null,
+          boardContext: safeContext(board, power),
+        };
+      }
+      // The human-visible thread store is passed so AI powers can answer open
+      // human threads — AI↔AI transcripts stay OUT of it (orchestrator contract).
+      if (conversations) agents.humanThreads = conversations;
+
+      const result = await runNegotiationPhase({
+        board,
+        state: diplomaticState,
+        agents,
+        askAgent,
+        options: { ...NEGOTIATION_OPTIONS, humanPower },
+      });
+      if (result && result.state) nextState = result.state;
+    } catch (_) {
+      // Any failure: keep the prior diplomatic state, continue the loop.
+    }
+
+    if (setDiplomaticState) setDiplomaticState(nextState);
+    busyRef.current = false;
+    setIsBusy(false);
+    setProgress('');
+    settle('negotiation', nextState);
+  }, [board, controllers, personas, conversations, diplomaticState, setDiplomaticState, humanPower, settle]);
+
+  // ----- orders phase: compute AI orders, merge human orders, adjudicate -----
+
+  // Compute the AI powers' orders (intent-bound, off-thread where possible) and
+  // return ordersByPower for the AI powers. Never throws.
+  const computeAiOrders = useCallback(async () => {
+    const aiPowers = aiPowersOf(controllers, board);
+    const intents = decideIntents(board, diplomaticState, aiPowers);
+    intentsRef.current = intents;
+    try {
+      return await bindOrders(board, intents, getOrders(), { difficulty: difficultyBudget.difficulty });
+    } catch (_) {
+      // Total failure -> every AI power holds (always legal).
+      const fallback = {};
+      for (const power of aiPowers) {
+        fallback[power] = board.getUnitLocations(power).map((unitLoc) => ({ type: 'hold', unitLoc }));
+      }
+      return fallback;
+    }
+  }, [board, controllers, diplomaticState, difficultyBudget, getOrders]);
+
+  // Submit the orders phase. `humanOrdersByPower` maps each human power to its
+  // entered orders (an object keyed by unitLoc or an array). AI orders are
+  // computed here. Adjudicates, feeds trust, advances to the resulting phase.
+  const submitOrders = useCallback(
+    async (humanOrdersByPower) => {
+      if (busyRef.current || !board.isOrdersPhase()) return;
+      busyRef.current = true;
+      setIsBusy(true);
+      setUiPhase('resolving');
+      setProgress('Resolving orders…');
+
+      const aiOrders = await computeAiOrders();
+
+      // Merge: human powers from the UI (default hold), AI powers from binding.
+      const ordersByPower = {};
+      for (const power of board.powers) {
+        if (controllers[power] === 'human') {
+          const entered = (humanOrdersByPower && humanOrdersByPower[power]) || {};
+          const list = Array.isArray(entered) ? entered : Object.values(entered);
+          ordersByPower[power] = board
+            .getUnitLocations(power)
+            .map((loc) => byLoc(list, loc) || { type: 'hold', unitLoc: loc });
+        } else if (aiOrders[power]) {
+          ordersByPower[power] = aiOrders[power];
+        }
+      }
+
+      const working = board.clone();
+      working.applyMove({ type: 'orders', ordersByPower });
+
+      // Feed honored/broken to the trust model exactly once for this orders phase.
+      let nextState = diplomaticState;
+      try {
+        const intents = intentsRef.current || {};
+        reconcileHonored(working, intents); // computed for symmetry / side-effect-free
+        const actingPowers = Object.keys(intents);
+        nextState = updateTrustAfterAdjudication(diplomaticState, working, { actingPowers });
+      } catch (_) {
+        nextState = diplomaticState;
+      }
+      if (setDiplomaticState) setDiplomaticState(nextState);
+
+      setBoard(working);
+      const nextUi = working.phase === 'game-over'
+        ? 'game-over'
+        : working.isRetreatPhase()
+          ? 'retreats'
+          : working.isWinterPhase()
+            ? 'winter'
+            : 'negotiation';
+      setUiPhase(nextUi);
+      busyRef.current = false;
+      setIsBusy(false);
+      setProgress('');
+      settle(nextUi, nextState);
+    },
+    [board, controllers, computeAiOrders, diplomaticState, setBoard, setDiplomaticState, settle]
+  );
+
+  // ----- retreat phase -----
+
+  const submitRetreats = useCallback(
+    async (humanRetreatsByPower) => {
+      if (busyRef.current || !board.isRetreatPhase()) return;
+      busyRef.current = true;
+      setIsBusy(true);
+      setProgress('Resolving retreats…');
+
+      const aiPowers = aiPowersOf(controllers, board);
+      const intents = decideIntents(board, diplomaticState, aiPowers);
+      let aiRetreats = {};
+      try {
+        aiRetreats = await bindRetreats(board, intents, getOrders(), { difficulty: difficultyBudget.difficulty });
+      } catch (_) {
+        aiRetreats = {};
+      }
+
+      const retreatsByPower = {};
+      for (const entry of board.pendingRetreats) {
+        const power = entry.unit.power;
+        if (!retreatsByPower[power]) retreatsByPower[power] = [];
+        if (controllers[power] === 'human') {
+          const human = (humanRetreatsByPower && humanRetreatsByPower[power]) || {};
+          const choice = human[entry.unitLoc];
+          const to = !choice || choice === 'DISBAND' ? null : choice;
+          retreatsByPower[power].push({ type: 'retreat', unitLoc: entry.unitLoc, to });
+        }
+      }
+      // Merge AI retreats (already legal per pendingRetreats options).
+      for (const [power, list] of Object.entries(aiRetreats)) {
+        if (controllers[power] === 'human') continue;
+        retreatsByPower[power] = (list || []).map((r) => ({ type: 'retreat', ...r }));
+      }
+
+      const working = board.clone();
+      working.applyMove({ type: 'retreats', retreatsByPower });
+      setBoard(working);
+      const nextUi = working.phase === 'game-over'
+        ? 'game-over'
+        : working.isWinterPhase()
+          ? 'winter'
+          : 'negotiation';
+      setUiPhase(nextUi);
+      busyRef.current = false;
+      setIsBusy(false);
+      setProgress('');
+      settle(nextUi, diplomaticState);
+    },
+    [board, controllers, diplomaticState, difficultyBudget, getOrders, setBoard, settle]
+  );
+
+  // ----- winter phase -----
+
+  const submitAdjustments = useCallback(
+    async (humanAdjustmentsByPower) => {
+      if (busyRef.current || !board.isWinterPhase()) return;
+      busyRef.current = true;
+      setIsBusy(true);
+      setProgress('Resolving adjustments…');
+
+      const aiPowers = aiPowersOf(controllers, board);
+      const intents = decideIntents(board, diplomaticState, aiPowers);
+      let aiAdj = {};
+      try {
+        aiAdj = await bindAdjustments(board, intents, getOrders(), { difficulty: difficultyBudget.difficulty });
+      } catch (_) {
+        aiAdj = {};
+      }
+
+      const adjustmentsByPower = {};
+      for (const power of board.powers) {
+        if (controllers[power] === 'human') {
+          adjustmentsByPower[power] = (humanAdjustmentsByPower && humanAdjustmentsByPower[power]) || [];
+        } else {
+          adjustmentsByPower[power] = aiAdj[power] || [];
+        }
+      }
+
+      const working = board.clone();
+      working.applyMove({ type: 'adjustments', adjustmentsByPower });
+      setBoard(working);
+      const nextUi = working.phase === 'game-over' ? 'game-over' : 'negotiation';
+      setUiPhase(nextUi);
+      busyRef.current = false;
+      setIsBusy(false);
+      setProgress('');
+      settle(nextUi, diplomaticState);
+    },
+    [board, controllers, diplomaticState, difficultyBudget, getOrders, setBoard, settle]
+  );
+
+  // Move from negotiation to order entry (the human's explicit "Proceed").
+  const proceedToOrders = useCallback(() => {
+    if (busyRef.current) return;
+    setUiPhase('orders');
+    settle('orders', diplomaticState);
+  }, [settle, diplomaticState]);
+
+  // Re-enter the saved UI phase on load (called by the game on mount-restore).
+  const restoreUiPhase = useCallback((phase) => {
+    if (phase) setUiPhase(phase);
+  }, []);
+
+  return {
+    uiPhase,
+    setUiPhase,
+    isBusy,
+    progress,
+    runNegotiation,
+    proceedToOrders,
+    submitOrders,
+    submitRetreats,
+    submitAdjustments,
+    restoreUiPhase,
+    hasKey: hasApiKey(),
+  };
+}
+
+// Find an order for a unit location in a list (matches by base/exact unitLoc).
+function byLoc(list, loc) {
+  if (!Array.isArray(list)) return null;
+  return list.find((o) => o && o.unitLoc === loc) || null;
+}
+
+// serializeBoardContext throws without a power; guard it so a missing power can't
+// abort negotiation setup.
+function safeContext(board, power) {
+  try {
+    return serializeBoardContext(board, { power });
+  } catch (_) {
+    return null;
+  }
+}
+
+export { makeGetOrders, decideIntents };


### PR DESCRIPTION
## Summary
Ties every prior Diplomacy piece (Board UI, tactical AI, conversational agents, AI-to-AI negotiation, intent binding) into one playable end-to-end loop and adds full versioned save/resume. After this, the experience exists: new-game setup -> per-season negotiation (human chat + bounded AI-to-AI) -> the human enters only their own power's orders while six AI powers are computed via intent binding + tactical AI -> adjudicate -> retreats -> winter -> next season, surviving a page reload.

Closes #30

## Validation evidence

### Tests
- `CI=true npm test`: full suite green — 40 suites, 766 tests pass.
- New diplomacy tests (stubbed agents, no real key in CI): full Spring 1901 turn (negotiation -> orders for all 7 powers -> `applyMove` true -> results from `orderHistory[0]`); dislodgement -> retreat phase; winter builds/disbands -> next Spring; no-key path completes a full year via the tactical fallback; an AI `getOrders` that throws falls back to holds and the phase still completes; difficulty threads the sim budget; persistence round-trip / per-uiPhase deep-equality / `QuotaExceededError` degrade / corrupt + old-version -> null / new-game clears all `diplomacy*` keys (keeps shared `gipfApiKey`); AI-to-AI sentinel never leaks into the human-visible conversations after save/reload.

### Manual verification
- `npm run build` completes without errors.
- `git diff` confirms `DiplomacyBoard.js` is unchanged (consumed only via clone/applyMove/serializeState).

## Affected areas
- **New:** `hooks/useDiplomacyTurn.js` (turn controller), `DiplomacySetup.jsx`, `diplomacySettings.js`, `diplomacyPersistence.js`, `diplomacyPersistence.test.js`, `DiplomacyTurnLoop.test.js`.
- **Changed:** `DiplomacyGame.jsx` (setup gate, turn-loop wiring, negotiation panel, human-only order entry, key-fallback prompt, save/resume), `diplomacy.css` (setup + status styles), `DiplomacyGame.test.js`.
- **Dependencies:** none.

## Review focus
- The UI `uiPhase` machine vs the engine phase (negotiation is UI-only; no Board edits) and the Catan-style `isBusy` re-entrancy guard.
- Graceful degradation paths (no key / per-power LLM failure / total failure) always terminate the phase and never emit illegal orders.
- Persistence guards: byte-cap trim, quota degrade, corrupt/version handling, and strict visible/hidden conversation separation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)