### PR TITLE
feat(diplomacy): carry conversation forward + bind LLM thinking to orders + deal-specific betrayal

### DIFF
--- a/api/diplomacyAgent.js
+++ b/api/diplomacyAgent.js
@@ -73,6 +73,22 @@ function buildSystemPrompt(body = {}) {
 
   const board = serializeContextLines(context);
 
+  // Prior-memory injection (issue #44): a brief carried summary of where this
+  // channel stands and the agent's own last private note about this rival, so
+  // negotiation has continuity across phases without an extra summarization call.
+  const priorSummary = typeof body.priorSummary === 'string' && body.priorSummary.trim()
+    ? body.priorSummary.trim().slice(0, 200)
+    : '';
+  const memory = typeof body.memory === 'string' && body.memory.trim()
+    ? body.memory.trim().slice(0, 400)
+    : '';
+  const memoryLines = [];
+  if (priorSummary) memoryLines.push(`Where this conversation stands: ${priorSummary}`);
+  if (memory) memoryLines.push(`Previously with this rival: ${memory}`);
+  const priorMemory = memoryLines.length
+    ? `\nPRIOR MEMORY (your own, private — use it for continuity, never reveal it)\n${memoryLines.join('\n')}\n`
+    : '';
+
   return `You are the leadership of ${name} in a game of the board game Diplomacy (classic 1901 European map). You are an AI player. A rival power — ${addressee} — is talking to you. Reply in character as ${name}'s envoy.
 
 YOUR PERSONA
@@ -83,7 +99,7 @@ ${dispoLines || '  - (no fixed dispositions; judge each power on the board state
 
 CURRENT BOARD
 ${board}
-
+${priorMemory}
 HOW DIPLOMACY WORKS (play to win)
 - Victory needs 18 of the 34 supply centers. Growth comes from taking centers, which usually requires another power's help (support) — so alliances are essential, and so are well-timed betrayals.
 - Orders are written and resolved simultaneously; words are not binding. You may promise anything. You may lie, mislead, or break a deal when it serves ${name} — that is core Diplomacy. But a reputation for treachery makes future deals harder, so weigh it.
@@ -96,7 +112,7 @@ HARD RULES
 - The visible reply must be PLAIN TEXT for a small chat panel: no markdown headers, no "#" lines, no "**bold**", no bullet markup. Write 1–4 short conversational sentences.
 
 OUTPUT FORMAT (critical)
-Return ONLY a single JSON object, no prose around it, with exactly two fields:
+Return ONLY a single JSON object, no prose around it, with these fields:
 {
   "message": "<the visible plain-text reply to the rival — in character, no markdown>",
   "scratchpad": {
@@ -104,9 +120,10 @@ Return ONLY a single JSON object, no prose around it, with exactly two fields:
     "dispositions": { "<other-power-id>": { "trust": <number in [-1,1]>, "stance": "ally|friendly|neutral|rival|enemy", "intent": "<your real plan toward them>", "note": "<optional private note>" } },
     "priority": "<your top objective this turn>",
     "confidence": <number in [0,1]>
-  }
+  },
+  "summary": "<optional, <=200 chars: one private line on where THIS conversation now stands, for your own future reference>"
 }
-The "scratchpad" is your PRIVATE strategic disposition — your true (possibly deceptive) intent toward each other power. It is never shown to the rival. Include one dispositions entry per other power you have a view on. Output valid JSON only.`;
+The "scratchpad" is your PRIVATE strategic disposition — your true (possibly deceptive) intent toward each other power. It is never shown to the rival. Include one dispositions entry per other power you have a view on. The optional "summary" is a private one-liner you write to your future self about this channel's state; keep it under 200 characters. Output valid JSON only.`;
 }
 
 // Render the serialized board context object into compact prompt lines. The
@@ -137,9 +154,10 @@ function serializeContextLines(context) {
   return lines.length ? lines.join('\n') : 'Opening position (Spring 1901): all powers at their home centers.';
 }
 
-// Defensively parse the model's reply: extract the visible message and validate
-// the scratchpad. Returns { message, scratchpad } where scratchpad is null when
-// it is missing or malformed. NEVER throws.
+// Defensively parse the model's reply: extract the visible message, validate the
+// scratchpad, and pull an optional one-line summary. Returns { message,
+// scratchpad, summary } where scratchpad is null when missing/malformed and
+// summary is '' when absent or oversized (> 200 chars). NEVER throws.
 function parseAgentReply(rawText) {
   const text = String(rawText || '').trim();
   let parsed = null;
@@ -160,15 +178,21 @@ function parseAgentReply(rawText) {
 
   let message = '';
   let scratchpad = null;
+  let summary = '';
   if (parsed && typeof parsed === 'object') {
     if (typeof parsed.message === 'string') message = parsed.message.trim();
     scratchpad = validateScratchpad(parsed.scratchpad) ? parsed.scratchpad : null;
+    // Optional summary: ignore if absent, non-string, empty, or oversized.
+    if (typeof parsed.summary === 'string') {
+      const s = parsed.summary.trim();
+      if (s && s.length <= 200) summary = s;
+    }
   }
   // Fallback: if JSON parsing failed entirely, surface the raw text as the
   // visible message (still strip obvious markdown emphasis) so the chat never
   // comes back empty.
   if (!message) message = text.replace(/\*\*/g, '').replace(/^#+\s*/gm, '').trim();
-  return { message, scratchpad };
+  return { message, scratchpad, summary };
 }
 
 // Returns true only for a well-formed scratchpad matching the documented shape.
@@ -258,8 +282,8 @@ export default async function handler(req, res) {
       .join('')
       .trim();
 
-    const { message, scratchpad } = parseAgentReply(rawText);
-    res.status(200).json({ message, scratchpad });
+    const { message, scratchpad, summary } = parseAgentReply(rawText);
+    res.status(200).json({ message, scratchpad, summary });
   } catch (err) {
     // Never include the request body (which holds the key) in error output.
     applyCors(req, res);

--- a/docs/diplomacy.md
+++ b/docs/diplomacy.md
@@ -78,7 +78,7 @@ agent layers touch the board only through `clone()` / `applyMove()` and read-onl
 | `src/games/diplomacy/agents/serializeContext.js` | Pure serializer turning a live board into a compact, prompt-friendly context object for one power |
 | `src/games/diplomacy/agents/memory.js` | Per-power conversation memory — visible thread + private scratchpad (disposition toward others) |
 | `src/games/diplomacy/agents/negotiator.js` | Negotiation orchestrator — runs bounded private pairwise AI↔AI conversations (and each AI's side of the human thread), extracting concrete deals |
-| `src/games/diplomacy/agents/diplomaticState.js` | Persisted cross-turn diplomatic state — who trusts whom, which deals stand, which promises were kept/broken |
+| `src/games/diplomacy/agents/diplomaticState.js` | Persisted cross-turn diplomatic state — who trusts whom, which deals stand, which promises were kept/broken, plus carried per-power scratchpads and per-channel conversation summaries |
 | `src/games/diplomacy/agents/trustModel.js` | Deterministic trust update — diffs promises against what units actually did, moving trust accordingly |
 | `src/games/diplomacy/agents/betrayalModel.js` | Per-agreement honor-vs-break decision; assembles the strategic-intent object the tactical AI consumes |
 | `src/games/diplomacy/agents/strategicIntent.js` | The strategic-intent schema + validator binding negotiation output to the tactical layer |
@@ -131,10 +131,24 @@ exactly:
   the full game but the AI powers won't chat or negotiate.
 
 The endpoint builds a per-power system prompt grounded in the serialized board state and
-returns two fields: a visible plain-text `message` for the chat panel and a structured,
+returns three fields: a visible plain-text `message` for the chat panel, a structured,
 **private** `scratchpad` (the agent's true, possibly deceptive, disposition toward every
-other power). The scratchpad is validated defensively, never shown to the human, and
+other power), and an optional one-line **`summary`** (≤ 200 chars: "where this conversation
+stands"). The scratchpad and summary are validated defensively, never shown to the human, and
 persisted by the caller for the trust/betrayal model.
+
+### Conversation continuity (no extra LLM call)
+
+Private negotiation **carries forward across phases** without a second model call. Each
+phase the orchestrator persists, in the hidden `diplomaticState`, the proposer's
+`scratchpad` (`scratchpads[power]`) and the channel `summary` (`summaries[channelId]`). On
+the next phase it re-injects both into the prompt as `priorSummary` (the carried channel
+summary) and `memory` (a one-line render of that power's own prior note about the rival —
+"Previously with this rival: …"). The agent self-summarizes in its existing reply, so
+continuity costs nothing extra, and everything stays bounded by the existing
+`messages.slice(-16)` upstream cap. These fields live **only** in `diplomaticState` (which is
+persisted but never rendered) — AI↔AI scratchpads and summaries are never written to the
+human-visible conversation store.
 
 ### CORS
 
@@ -165,6 +179,37 @@ accordingly (verified promises clear; durable ones are promoted to standing agre
 emits a strategic-intent object, which `intentBinding.js` turns into the orders the tactical
 engine actually submits. So an alliance or betrayal changes resolved orders, not just chat
 text.
+
+### Thinking → orders: the trust blend
+
+The agent's private "thinking" reaches the order pipeline through the persisted scratchpad.
+`betrayalModel.js` blends the mechanical ledger trust with the scratchpad's self-reported
+trust, **ledger-dominant**:
+
+```
+effectiveTrust(partner) = clamp(W_LEDGER · ledgerTrust + W_SCRATCH · scratchpadTrust, -1, 1)
+```
+
+with `W_LEDGER` (0.7) **>** `W_SCRATCH` (0.3) — both exported constants. The verifiable
+kept/broken-promise ledger is the backbone, so a hallucinated "I trust you" can never
+override a partner who actually stabbed last turn, while genuine private reasoning still
+steers the honor-vs-break decision. The scratchpad also adds **deal-less** powers to
+`targets`: an `enemy` stance (or a `rival` stance with a hostile `intent`) toward a power you
+hold no agreement with presses them; an `ally`/`friendly` stance keeps them out of targets
+unless the ledger contradicts it. The function stays pure and deterministic in its inputs.
+
+### Deal-specific betrayal payoff
+
+Betrayal is decided **per agreement**, not all-or-nothing. `payoffOfBreaking(board, power,
+agreement)` generates candidate plans (`board.generateCandidatePlans`) and partitions them
+into **honor-consistent** plans — those that keep the agreement's promised support, avoid its
+DMZ provinces, or don't move into the partner's occupied centers (a small per-type
+predicate) — versus **all** plans. The gain is `(bestFreeScore − bestHonorScore) /
+PAYOFF_SCALE`, clamped to `[0, ∞)`; if no honor-consistent plan exists, the all-hold score is
+the honor baseline so the result stays finite and deterministic. So a deal that barely
+constrains a power yields a small gain (honored) while one blocking a high-value center grab
+yields a large gain (broken) — two deals for the same power can resolve differently in the
+same turn. Tests/tuning may still inject a `payoff` override (number or function).
 
 ## Difficulty and settings
 

--- a/src/games/diplomacy/agents/agentClient.js
+++ b/src/games/diplomacy/agents/agentClient.js
@@ -100,7 +100,7 @@ export async function sendMessage({ power, history, context, addressee, model, s
     return { error: 'empty', message: 'No reply came back. Try again.' };
   }
 
-  const result = { message: data.message, scratchpad: data.scratchpad || null };
+  const result = { message: data.message, scratchpad: data.scratchpad || null, summary: data.summary || '' };
 
   // Wire the result through memory when a store is supplied: append the visible
   // reply and persist the latest scratchpad.
@@ -117,9 +117,12 @@ export async function sendMessage({ power, history, context, addressee, model, s
 // adds AI↔AI negotiation fields (channel, counterparties) and never writes to any
 // memory store itself — the orchestrator owns transcript/state persistence and
 // keeps AI↔AI text out of the human-visible thread store.
-//   { power, counterparties, channel, boardContext, persona, messages, model }
-// Returns { reply: { message, scratchpad } } on success, or { error, reply }
-// mirroring sendMessage's error contract (no key / network / upstream).
+//   { power, counterparties, channel, boardContext, persona, messages, model,
+//     priorSummary, memory }
+//   - priorSummary: a brief carried summary of where this channel stands (#44)
+//   - memory:       the agent's own prior private note about this rival (#44)
+// Returns { reply: { message, scratchpad, summary } } on success, or
+// { error, reply } mirroring sendMessage's error contract.
 export async function askAgent({
   power,
   counterparties = [],
@@ -128,6 +131,8 @@ export async function askAgent({
   persona,
   messages,
   model,
+  priorSummary,
+  memory,
 } = {}) {
   const apiKey = getApiKey();
   if (!apiKey) {
@@ -151,6 +156,8 @@ export async function askAgent({
         counterparties,
         channel,
         model,
+        priorSummary,
+        memory,
       }),
     });
   } catch (_) {
@@ -162,5 +169,11 @@ export async function askAgent({
   }
 
   const data = await res.json();
-  return { reply: { message: (data && data.message) || '', scratchpad: (data && data.scratchpad) || null } };
+  return {
+    reply: {
+      message: (data && data.message) || '',
+      scratchpad: (data && data.scratchpad) || null,
+      summary: (data && data.summary) || '',
+    },
+  };
 }

--- a/src/games/diplomacy/agents/agentClient.test.js
+++ b/src/games/diplomacy/agents/agentClient.test.js
@@ -7,6 +7,7 @@ import {
   setApiKey,
   hasApiKey,
   sendMessage,
+  askAgent,
   createMemory,
 } from './agentClient.js';
 
@@ -84,7 +85,7 @@ describe('sendMessage', () => {
     expect(body.addressee).toBe('France');
     expect(body.model).toBe('claude-opus-4-8');
 
-    expect(result).toEqual({ message: 'We watch Belgium too.', scratchpad: SCRATCHPAD });
+    expect(result).toEqual({ message: 'We watch Belgium too.', scratchpad: SCRATCHPAD, summary: '' });
   });
 
   test('wires the reply and scratchpad through a provided memory store', async () => {
@@ -112,5 +113,45 @@ describe('sendMessage', () => {
     global.fetch = okFetch({ message: '', scratchpad: null });
     const result = await sendMessage({ power: 'germany', history: [{ role: 'user', content: 'hi' }], context: {} });
     expect(result.error).toBe('empty');
+  });
+});
+
+describe('askAgent', () => {
+  test('with no key returns error and never calls fetch', async () => {
+    global.fetch = jest.fn();
+    const result = await askAgent({ power: 'germany', counterparties: ['france'], messages: [{ role: 'user', content: 'hi' }] });
+    expect(result.error).toBe('no_key');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('threads priorSummary/memory into the POST body and surfaces summary in the reply', async () => {
+    setApiKey('sk-live');
+    global.fetch = okFetch({ message: 'We hold the line.', scratchpad: SCRATCHPAD, summary: 'Tense over Belgium.' });
+
+    const result = await askAgent({
+      power: 'germany',
+      counterparties: ['france'],
+      channel: 'france~germany',
+      messages: [{ role: 'user', content: 'Belgium?' }],
+      priorSummary: 'Last phase we agreed to a DMZ.',
+      memory: 'stance rival; trust -0.10',
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body.priorSummary).toBe('Last phase we agreed to a DMZ.');
+    expect(body.memory).toBe('stance rival; trust -0.10');
+    expect(body.counterparties).toEqual(['france']);
+
+    expect(result.reply.message).toBe('We hold the line.');
+    expect(result.reply.scratchpad).toEqual(SCRATCHPAD);
+    expect(result.reply.summary).toBe('Tense over Belgium.');
+  });
+
+  test('summary defaults to empty string when the endpoint omits it', async () => {
+    setApiKey('sk-live');
+    global.fetch = okFetch({ message: 'Noted.', scratchpad: null });
+    const result = await askAgent({ power: 'germany', counterparties: ['france'], messages: [{ role: 'user', content: 'hi' }] });
+    expect(result.reply.summary).toBe('');
   });
 });

--- a/src/games/diplomacy/agents/betrayalModel.js
+++ b/src/games/diplomacy/agents/betrayalModel.js
@@ -8,20 +8,26 @@
 // is testable and reproducible.)
 //
 // Decision rule per agreement involving `power` and `partner`:
-//   honorScore = trust(partner) * W_trust  -  reputationCost(partner) * W_rep
-//   breakScore = payoffGain(breaking)      *  W_payoff
+//   honorScore = effectiveTrust(partner) * W_trust - reputationCost(partner) * W_rep
+//   breakScore = payoffGain(breaking)             *  W_payoff
 //   BREAK iff breakScore > honorScore + MARGIN
+//
+// effectiveTrust (#44) blends the mechanical ledger trust with the LLM
+// scratchpad's self-reported trust, LEDGER-DOMINANT (W_LEDGER > W_SCRATCH), so the
+// model's private "thinking" steers the decision but can't override a verifiable
+// betrayal. The scratchpad also adds deal-less hostile powers to `targets`.
 //
 // reputationCost(partner) scales with how treacherous the power has already been
 // toward that partner (its broken/kept ledger), weighted by the trust deltas, so
 // a power that has burned a partner before pays less marginal reputation to do it
 // again — but a clean reputation makes the first stab expensive.
 
-import { POWERS } from '../DiplomacyBoard.js';
+import { POWERS, baseProvince } from '../DiplomacyBoard.js';
 import {
   getTrust,
   getLedger,
   getAgreementsFor,
+  getScratchpad,
   agreementPartner,
 } from './diplomaticState.js';
 import { TRUST_DELTAS } from './trustModel.js';
@@ -31,6 +37,54 @@ export const W_TRUST = 1.0;   // weight on trusting an ally (favors honoring)
 export const W_REP = 1.0;     // weight on reputational cost of betrayal
 export const W_PAYOFF = 1.0;  // weight on the tactical gain from breaking
 export const MARGIN = 0.15;   // breaking must clear honoring by this much
+
+// Trust-blend weights (#44): the verifiable kept/broken-promise LEDGER dominates;
+// the LLM scratchpad's self-reported trust is a bounded secondary adjustment, so
+// a hallucinated "I trust you" can never override a partner who actually stabbed.
+// W_LEDGER > W_SCRATCH by construction; they sum to 1 so the blend stays in [-1,1].
+export const W_LEDGER = 0.7;
+export const W_SCRATCH = 0.3;
+
+function clamp(x, lo, hi) {
+  return Math.max(lo, Math.min(hi, x));
+}
+
+// Effective trust toward `partner`: the ledger-derived trust blended with the
+// power's own scratchpad disposition (if any), ledger-dominant. Falls back to
+// pure ledger trust when no scratchpad note about the partner exists.
+export function effectiveTrust(state, power, partner) {
+  const ledgerTrust = getTrust(state, power, partner);
+  const d = scratchpadDisposition(state, power, partner);
+  if (!d || typeof d.trust !== 'number') return ledgerTrust;
+  return clamp(W_LEDGER * ledgerTrust + W_SCRATCH * d.trust, -1, 1);
+}
+
+// The power's persisted disposition toward one partner ({ trust, stance, intent,
+// note }), or null if none recorded. Pure read.
+function scratchpadDisposition(state, power, partner) {
+  const scratchpad = state ? getScratchpad(state, power) : null;
+  if (!scratchpad || !scratchpad.dispositions) return null;
+  const d = scratchpad.dispositions[partner];
+  return d && typeof d === 'object' ? d : null;
+}
+
+// True if the power's scratchpad marks `partner` as hostile enough to press them
+// even absent a standing deal: an explicit 'enemy' stance, or a 'rival' stance
+// paired with a clearly hostile intent. Conservative + deterministic.
+const HOSTILE_INTENT = /\b(stab|attack|invade|destroy|crush|betray|eliminate|take .* from|seize)\b/i;
+function scratchpadMarksHostile(d) {
+  if (!d) return false;
+  if (d.stance === 'enemy') return true;
+  if (d.stance === 'rival' && typeof d.intent === 'string' && HOSTILE_INTENT.test(d.intent)) return true;
+  return false;
+}
+
+// True if the scratchpad marks `partner` as a friend the power means to keep:
+// an 'ally' or 'friendly' stance. Used to keep them OUT of targets unless the
+// ledger contradicts it.
+function scratchpadMarksFriendly(d) {
+  return !!d && (d.stance === 'ally' || d.stance === 'friendly');
+}
 
 // Normalizing scale for the raw tactical-payoff proxy (board score units are in
 // the hundreds; this maps a meaningful gain to roughly [0,1]).
@@ -49,21 +103,80 @@ export function reputationCost(state, power, partner) {
   return base * reliability;
 }
 
-// Local tactical-payoff proxy: how much standing this power could gain by NOT
-// being bound by its deals — approximated from the best candidate plan's score
-// relative to its current footprint. Returns a value in ~[0,1] after scaling.
-// Callers may inject `payoff` to override (e.g. a real search signal).
-function defaultPayoffGain(board, power) {
-  if (!board || typeof board.generateCandidatePlans !== 'function') return 0;
+// Deal-specific betrayal payoff (#44): how much THIS power gains by breaking THIS
+// specific agreement, rather than one global number applied to all deals.
+//
+// Generate candidate plans, then partition them: the FREE best is the top plan
+// overall; the HONOR best is the top plan that stays consistent with the
+// agreement (keeps a promised support / avoids DMZ provinces / does not move into
+// the partner's occupied centers — a small predicate per agreement type). The
+// gain is the score the power forgoes by honoring, scaled and clamped to [0, ∞).
+// If no honor-consistent plan exists, the holding plan is the honor baseline so
+// the result stays finite and deterministic.
+export function payoffOfBreaking(board, power, agreement) {
+  if (!board || typeof board.generateCandidatePlans !== 'function' || !agreement) return 0;
   let plans;
   try {
-    plans = board.generateCandidatePlans(power, { maxPlans: 8 });
+    plans = board.generateCandidatePlans(power, { maxPlans: 16 });
   } catch (_) {
     return 0;
   }
   if (!Array.isArray(plans) || plans.length === 0) return 0;
-  const best = plans.reduce((m, p) => Math.max(m, p.score || 0), 0);
-  return best / PAYOFF_SCALE;
+
+  const partner = agreementPartner(agreement, power);
+  const isHonorConsistent = honorPredicate(board, power, agreement, partner);
+
+  let bestFree = -Infinity;
+  let bestHonor = -Infinity;
+  for (const plan of plans) {
+    const s = typeof plan.score === 'number' ? plan.score : 0;
+    if (s > bestFree) bestFree = s;
+    if (isHonorConsistent(plan) && s > bestHonor) bestHonor = s;
+  }
+  if (bestFree === -Infinity) return 0;
+  // No honor-consistent plan: hold (no aggressive move) is the honor baseline.
+  if (bestHonor === -Infinity) bestHonor = holdingScore(board, power);
+
+  const gain = (bestFree - bestHonor) / PAYOFF_SCALE;
+  return gain > 0 ? gain : 0;
+}
+
+// Score of the all-hold plan for `power` — the deterministic honor baseline when
+// every candidate plan violates the agreement. Sums per-unit hold scores.
+function holdingScore(board, power) {
+  if (typeof board.getUnitLocations !== 'function' || typeof board.scoreOrder !== 'function') return 0;
+  let score = 0;
+  for (const unitLoc of board.getUnitLocations(power)) {
+    score += board.scoreOrder({ type: 'hold', unitLoc }, power);
+  }
+  return score;
+}
+
+// Build a predicate: does a candidate plan keep `agreement` intact?
+//   - dmz:            no order moves INTO any DMZ province.
+//   - non-aggression: no order moves INTO a center occupied by the partner.
+//   - joint-attack:   same as non-aggression toward the partner (don't attack
+//                     the ally; honoring it presses the agreed target, not them).
+//   - support:        keep the promised direction — don't move into the partner's
+//                     occupied centers (a verifiable, plan-level constraint).
+function honorPredicate(board, power, agreement, partner) {
+  // Province ids are compared case-insensitively: agreements store lower-case ids
+  // (e.g. 'spa') while board move targets are upper-case (e.g. 'SPA').
+  const norm = (loc) => baseProvince(loc).toLowerCase();
+  const movesInto = (plan, baseSet) =>
+    (plan.orders || []).some((o) => o && o.type === 'move' && o.to && baseSet.has(norm(o.to)));
+
+  if (agreement.type === 'dmz') {
+    const dmz = new Set((agreement.provinces || []).map(norm));
+    return (plan) => !movesInto(plan, dmz);
+  }
+
+  // Province bases the partner currently occupies (don't move into them).
+  const partnerBases = new Set();
+  if (partner && typeof board.getUnitLocations === 'function') {
+    for (const loc of board.getUnitLocations(partner)) partnerBases.add(norm(loc));
+  }
+  return (plan) => !movesInto(plan, partnerBases);
 }
 
 // Threat list from the board: rival powers pressing this power, derived from
@@ -88,11 +201,11 @@ function boardThreats(board, power) {
 
 // decideStrategicIntent({ board, state, power, payoff, seed }) -> strategic intent.
 //
-//   payoff: optional override for the per-power tactical-gain proxy. Either a
+//   payoff: optional override for the per-agreement gain-from-breaking. Either a
 //           number (applied to every agreement) or a function (board, power,
-//           agreement) -> number in ~[0,1]. Defaults to a local proxy via
-//           generateCandidatePlans/scoreOrder. No randomness unless `seed` given
-//           (the decision is deterministic in its inputs regardless).
+//           agreement) -> number in ~[0,1]. Defaults to payoffOfBreaking, a
+//           DEAL-SPECIFIC proxy (honor-constrained best plan vs. free best plan).
+//           Deterministic in its inputs.
 export function decideStrategicIntent({ board, state, power, payoff } = {}) {
   if (!power || typeof power !== 'string') {
     throw new Error('decideStrategicIntent requires a power');
@@ -109,16 +222,22 @@ export function decideStrategicIntent({ board, state, power, payoff } = {}) {
   const payoffOf = (agreement) => {
     if (typeof payoff === 'number') return payoff;
     if (typeof payoff === 'function') return payoff(board, power, agreement);
-    return defaultPayoffGain(board, power);
+    // Per-agreement gain-from-breaking (#44), not one global number.
+    return payoffOfBreaking(board, power, agreement);
   };
 
   const agreements = state ? getAgreementsFor(state, power) : [];
+  // Partners with a standing agreement: the scratchpad-only targeting below only
+  // applies to powers we have NO deal with (deals are resolved by the loop).
+  const partnersWithDeal = new Set();
 
   for (const agreement of agreements) {
     const partner = agreementPartner(agreement, power);
     if (!partner) continue;
+    partnersWithDeal.add(partner);
 
-    const trust = state ? getTrust(state, power, partner) : 0;
+    // Ledger-dominant blend (#44): mechanical trust adjusted by the scratchpad.
+    const trust = state ? effectiveTrust(state, power, partner) : 0;
     const rep = state ? reputationCost(state, power, partner) : 0;
     const gain = payoffOf(agreement);
 
@@ -158,10 +277,34 @@ export function decideStrategicIntent({ board, state, power, payoff } = {}) {
   // Honoring a non-aggression / DMZ keeps the partner OUT of targets.
   for (const p of honoredPartners) targets.delete(p);
 
+  // Thinking → pipeline (#44): the persisted scratchpad steers targets even with
+  // NO standing deal. A hostile stance (enemy, or rival with a hostile intent)
+  // toward a deal-less power presses them; a friendly/ally stance keeps them out
+  // of targets — unless the ledger contradicts it (ledger dominates).
+  const scratchpad = state ? getScratchpad(state, power) : null;
+  if (scratchpad && scratchpad.dispositions) {
+    for (const partner of Object.keys(scratchpad.dispositions)) {
+      if (partner === power || partnersWithDeal.has(partner)) continue;
+      const d = scratchpad.dispositions[partner];
+      if (scratchpadMarksHostile(d)) {
+        targets.add(partner);
+        allies.delete(partner);
+      } else if (scratchpadMarksFriendly(d)) {
+        // Keep a self-declared friend off the target list only when the ledger
+        // does not already distrust them (effectiveTrust >= 0).
+        if (effectiveTrust(state, power, partner) >= 0) {
+          allies.add(partner);
+          honoredPartners.add(partner);
+          targets.delete(partner);
+        }
+      }
+    }
+  }
+
   // Add board-derived threats so a power with no (or only honored) agreements
   // still has someone to press — but never a current ally.
   for (const t of boardThreats(board, power)) {
-    if (!honoredPartners.has(t)) targets.add(t);
+    if (!honoredPartners.has(t) && !allies.has(t)) targets.add(t);
   }
 
   return {

--- a/src/games/diplomacy/agents/betrayalModel.test.js
+++ b/src/games/diplomacy/agents/betrayalModel.test.js
@@ -6,9 +6,13 @@ import {
   decideStrategicIntent,
   decideAllIntents,
   reputationCost,
+  effectiveTrust,
+  payoffOfBreaking,
   W_TRUST,
   W_REP,
   W_PAYOFF,
+  W_LEDGER,
+  W_SCRATCH,
   MARGIN,
 } from './betrayalModel.js';
 
@@ -16,6 +20,16 @@ import {
 function withTrust(state, from, to, trust) {
   const next = JSON.parse(JSON.stringify(state));
   next.relations[relationKey(from, to)] = { trust, lastUpdatedPhase: null };
+  return next;
+}
+
+// Attach a private scratchpad disposition for `power` toward `partner`.
+function withScratchpad(state, power, partner, disposition) {
+  const next = JSON.parse(JSON.stringify(state));
+  if (!next.scratchpads) next.scratchpads = {};
+  const pad = next.scratchpads[power] || { self: power, dispositions: {}, priority: '', confidence: 0.5 };
+  pad.dispositions = { ...pad.dispositions, [partner]: disposition };
+  next.scratchpads[power] = pad;
   return next;
 }
 
@@ -146,8 +160,169 @@ describe('reputationCost', () => {
   });
 });
 
+describe('payoffOfBreaking — deal-specific gain (#44)', () => {
+  // On a fresh board France's reachable move targets are SPA, BRE, ENG, MAO.
+  const REACHABLE = ['spa', 'bre', 'eng', 'mao'];
+
+  test('a low-constraint deal yields a small (near-zero) gain', () => {
+    const board = new DiplomacyBoard();
+    // DMZ over a province France cannot reach this turn → honoring costs nothing.
+    const deal = { type: 'dmz', parties: ['france', 'italy'], provinces: ['mos'] };
+    expect(payoffOfBreaking(board, 'france', deal)).toBe(0);
+  });
+
+  test('a deal blocking all of a power\'s grabs yields a large gain', () => {
+    const board = new DiplomacyBoard();
+    const deal = { type: 'dmz', parties: ['france', 'italy'], provinces: REACHABLE };
+    expect(payoffOfBreaking(board, 'france', deal)).toBeGreaterThan(0.5);
+  });
+
+  test('the high-constraint gain exceeds the low-constraint gain for the same power/turn', () => {
+    const board = new DiplomacyBoard();
+    const low = payoffOfBreaking(board, 'france', { type: 'dmz', parties: ['france', 'italy'], provinces: ['mos'] });
+    const high = payoffOfBreaking(board, 'france', { type: 'dmz', parties: ['france', 'italy'], provinces: REACHABLE });
+    expect(high).toBeGreaterThan(low);
+  });
+
+  test('clamps to [0, ∞) and is deterministic', () => {
+    const board = new DiplomacyBoard();
+    const deal = { type: 'dmz', parties: ['france', 'italy'], provinces: REACHABLE };
+    const a = payoffOfBreaking(board, 'france', deal);
+    const b = payoffOfBreaking(board, 'france', deal);
+    expect(a).toBe(b);
+    expect(a).toBeGreaterThanOrEqual(0);
+  });
+
+  test('returns 0 when the board cannot generate plans', () => {
+    expect(payoffOfBreaking(null, 'france', { type: 'dmz', provinces: ['spa'] })).toBe(0);
+    expect(payoffOfBreaking({}, 'france', { type: 'dmz', provinces: ['spa'] })).toBe(0);
+  });
+});
+
+describe('decideStrategicIntent — per-deal betrayal resolves deals independently (#44)', () => {
+  const REACHABLE = ['spa', 'bre', 'eng', 'mao'];
+
+  test('two deals for the same power can resolve differently in one turn', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    // Moderate positive trust on both so the per-deal PAYOFF decides honor vs
+    // break: the low-constraint deal (gain 0) stays honored, the high-constraint
+    // one (large gain) is broken.
+    state = withTrust(state, 'france', 'italy', 0.5);
+    state = withTrust(state, 'france', 'germany', 0.5);
+    // A low-constraint DMZ with italy (honored) and a high-constraint DMZ with
+    // germany (broken) — same power, same turn, opposite outcomes.
+    state = recordAgreement(state, { id: 'd-low', type: 'dmz', parties: ['france', 'italy'], provinces: ['mos'] });
+    state = recordAgreement(state, { id: 'd-high', type: 'dmz', parties: ['france', 'germany'], provinces: REACHABLE });
+
+    const intent = decideStrategicIntent({ board, state, power: 'france' });
+    const brokenPartners = intent.betrayals.map((bt) => bt.partner);
+    expect(brokenPartners).toContain('germany'); // high-value grab → stab
+    expect(brokenPartners).not.toContain('italy'); // low-stakes deal → honored
+    expect(intent.allies).toContain('italy');
+    expect(validateStrategicIntent(intent)).toBe(true);
+  });
+
+  test('an injected payoff still overrides the per-deal proxy', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    state = recordAgreement(state, { id: 'a1', type: 'dmz', parties: ['france', 'germany'], provinces: REACHABLE });
+    state = withTrust(state, 'france', 'germany', 0.7);
+    // Force a tiny payoff so the high-constraint deal is honored despite its real
+    // (large) gain-from-breaking — proving the override wins.
+    const intent = decideStrategicIntent({ board, state, power: 'france', payoff: 0 });
+    expect(intent.betrayals).toEqual([]);
+    expect(intent.allies).toContain('germany');
+  });
+});
+
 describe('exported weights', () => {
   test('all decision weights are numbers', () => {
-    [W_TRUST, W_REP, W_PAYOFF, MARGIN].forEach((w) => expect(typeof w).toBe('number'));
+    [W_TRUST, W_REP, W_PAYOFF, W_LEDGER, W_SCRATCH, MARGIN].forEach((w) => expect(typeof w).toBe('number'));
+  });
+
+  test('the ledger weight dominates the scratchpad weight', () => {
+    expect(W_LEDGER).toBeGreaterThan(W_SCRATCH);
+  });
+});
+
+describe('effectiveTrust — ledger-dominant blend (#44)', () => {
+  test('falls back to pure ledger trust with no scratchpad note', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    state = withTrust(state, 'france', 'germany', 0.6);
+    expect(effectiveTrust(state, 'france', 'germany')).toBeCloseTo(0.6, 5);
+  });
+
+  test('blends ledger and scratchpad, ledger dominant', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    state = withTrust(state, 'france', 'germany', 0.9);
+    state = withScratchpad(state, 'france', 'germany', { trust: -0.5, stance: 'rival', intent: 'wary' });
+    // 0.7*0.9 + 0.3*(-0.5) = 0.63 - 0.15 = 0.48 — still clearly positive.
+    expect(effectiveTrust(state, 'france', 'germany')).toBeCloseTo(W_LEDGER * 0.9 + W_SCRATCH * -0.5, 5);
+    expect(effectiveTrust(state, 'france', 'germany')).toBeGreaterThan(0);
+  });
+
+  test('clamps to [-1, 1]', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    state = withTrust(state, 'france', 'germany', 1);
+    state = withScratchpad(state, 'france', 'germany', { trust: 1, stance: 'ally', intent: 'friends' });
+    expect(effectiveTrust(state, 'france', 'germany')).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('decideStrategicIntent — scratchpad steers intent (#44)', () => {
+  test('a hostile scratchpad puts a deal-less rival into targets', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    // No agreement with germany; france privately marks them an enemy to stab.
+    state = withScratchpad(state, 'france', 'germany', { trust: -0.6, stance: 'enemy', intent: 'Stab them in Burgundy.' });
+
+    const intent = decideStrategicIntent({ board, state, power: 'france', payoff: 0 });
+    expect(intent.targets).toContain('germany');
+    expect(intent.allies).not.toContain('germany');
+    // No mechanically-broken deal exists.
+    expect(intent.betrayals).toEqual([]);
+    expect(validateStrategicIntent(intent)).toBe(true);
+  });
+
+  test('a rival stance needs a hostile intent to target a deal-less power', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    // 'rival' but with a non-hostile intent → not auto-targeted by the scratchpad
+    // rule (board threats may still apply, so use a power that is not a threat:
+    // assert only that the rule itself does not force it via a friendly stance).
+    state = withScratchpad(state, 'france', 'italy', { trust: 0.1, stance: 'ally', intent: 'Keep the peace.' });
+    const intent = decideStrategicIntent({ board, state, power: 'france', payoff: 0 });
+    // A self-declared ally (no contradicting ledger) is kept out of targets.
+    expect(intent.targets).not.toContain('italy');
+    expect(intent.allies).toContain('italy');
+  });
+
+  test('ledger dominates a scratchpad it disagrees with: high ledger trust keeps a deal honored', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    state = recordAgreement(state, { id: 'a1', type: 'non-aggression', parties: ['france', 'germany'] });
+    state = withTrust(state, 'france', 'germany', 0.9); // ledger: very trusted
+    state = withScratchpad(state, 'france', 'germany', { trust: -0.5, stance: 'rival', intent: 'wary of them' });
+
+    // effectiveTrust = 0.7*0.9 + 0.3*(-0.5) = 0.48 > 0 → honored (with low payoff).
+    const intent = decideStrategicIntent({ board, state, power: 'france', payoff: 0.05 });
+    expect(intent.betrayals).toEqual([]);
+    expect(intent.allies).toContain('germany');
+    expect(intent.targets).not.toContain('germany');
+  });
+
+  test('scratchpad targeting is deterministic and does not mutate input', () => {
+    const board = new DiplomacyBoard();
+    let state = createDiplomaticState({ board, humanPower: 'england' });
+    state = withScratchpad(state, 'france', 'germany', { trust: -0.6, stance: 'enemy', intent: 'attack' });
+    const before = JSON.parse(JSON.stringify(state));
+    const a = decideStrategicIntent({ board, state, power: 'france', payoff: 0 });
+    const b = decideStrategicIntent({ board, state, power: 'france', payoff: 0 });
+    expect(a).toEqual(b);
+    expect(state).toEqual(before);
   });
 });

--- a/src/games/diplomacy/agents/diplomaticState.js
+++ b/src/games/diplomacy/agents/diplomaticState.js
@@ -16,8 +16,15 @@
 //     relations:  { 'france>germany': { trust: 0.42, lastUpdatedPhase: 'Fall 1902' } },
 //     agreements: [ { id, type, ... } ],          // standing, durable deals
 //     promises:   [ { id, type, from, to, expectedOrder, madePhase, actingPower } ],
-//     promiseLedger: { 'france>germany': { kept: 3, broken: 1 } }
+//     promiseLedger: { 'france>germany': { kept: 3, broken: 1 } },
+//     scratchpads: { france: <scratchpad> },        // last private disposition per power
+//     summaries:   { 'austria~france': '...' }       // one-line per-channel memory
 //   }
+//
+// `scratchpads` and `summaries` (issue #44) carry the conversational layer's
+// memory forward across negotiation phases without an extra LLM call: an agent's
+// own scratchpad (from api/diplomacyAgent.js) and a brief self-emitted channel
+// summary are persisted here and re-injected into the next phase's prompts.
 //
 // `relations` holds one entry for EVERY ordered pair of alive powers (so both
 // 'france>germany' and 'germany>france' exist) seeded at trust 0. The pair key
@@ -59,6 +66,8 @@ export function createDiplomaticState({ board, humanPower } = {}) {
     agreements: [],
     promises: [],
     promiseLedger: {},
+    scratchpads: {},
+    summaries: {},
   };
 }
 
@@ -132,6 +141,33 @@ export function dropAgreement(state, id) {
   return next;
 }
 
+// Persist a power's latest private scratchpad (the disposition object from the
+// agent endpoint). Returns new state. A null/undefined scratchpad clears it; any
+// other value is stored verbatim (the endpoint already validated its shape).
+export function setScratchpad(state, power, scratchpad) {
+  if (!power || typeof power !== 'string') return state;
+  const next = cloneState(state);
+  if (!next.scratchpads || typeof next.scratchpads !== 'object') next.scratchpads = {};
+  if (scratchpad == null) {
+    delete next.scratchpads[power];
+  } else {
+    next.scratchpads[power] = scratchpad;
+  }
+  return next;
+}
+
+// Persist a brief one-line conversation summary for a channel. Returns new state.
+// Empty / non-string / oversized (> 200 chars) text is ignored (no-op) so a bad
+// agent emission never corrupts the carried memory.
+export function setSummary(state, channelId, text) {
+  if (!channelId || typeof channelId !== 'string') return state;
+  if (typeof text !== 'string' || !text.trim() || text.length > 200) return state;
+  const next = cloneState(state);
+  if (!next.summaries || typeof next.summaries !== 'object') next.summaries = {};
+  next.summaries[channelId] = text.trim();
+  return next;
+}
+
 // --- getters (read-only, never mutate) --------------------------------------
 
 // A's trust toward B in [-1,1]; 0 if the pair has no relation entry.
@@ -143,6 +179,16 @@ export function getTrust(state, from, to) {
 // Ledger {kept,broken} for A toward B; zeros if none recorded yet.
 export function getLedger(state, from, to) {
   return state.promiseLedger[relationKey(from, to)] || { kept: 0, broken: 0 };
+}
+
+// A power's persisted private scratchpad, or null if none recorded yet.
+export function getScratchpad(state, power) {
+  return (state.scratchpads && state.scratchpads[power]) || null;
+}
+
+// The carried one-line summary for a channel, or '' if none recorded yet.
+export function getSummary(state, channelId) {
+  return (state.summaries && state.summaries[channelId]) || '';
 }
 
 // All standing agreements that involve `power` (as a party / from / to).

--- a/src/games/diplomacy/agents/diplomaticState.test.js
+++ b/src/games/diplomacy/agents/diplomaticState.test.js
@@ -11,6 +11,10 @@ import {
   getPromisesBy,
   agreementInvolves,
   agreementPartner,
+  setScratchpad,
+  setSummary,
+  getScratchpad,
+  getSummary,
   STATE_VERSION,
 } from './diplomaticState.js';
 
@@ -34,7 +38,7 @@ describe('createDiplomaticState', () => {
     expect(state.relations['france>france']).toBeUndefined();
   });
 
-  test('starts with empty agreements, promises, and ledger; version stamped', () => {
+  test('starts with empty agreements, promises, ledger, scratchpads, summaries; version stamped', () => {
     const board = new DiplomacyBoard();
     const state = createDiplomaticState({ board, humanPower: 'france' });
     expect(state).toMatchObject({
@@ -43,6 +47,8 @@ describe('createDiplomaticState', () => {
       agreements: [],
       promises: [],
       promiseLedger: {},
+      scratchpads: {},
+      summaries: {},
     });
   });
 
@@ -153,6 +159,11 @@ describe('getters', () => {
     expect(getPromisesBy(state, 'turkey')).toHaveLength(0);
   });
 
+  test('getScratchpad / getSummary return null / empty when nothing recorded', () => {
+    expect(getScratchpad(state, 'france')).toBeNull();
+    expect(getSummary(state, 'austria~france')).toBe('');
+  });
+
   test('agreementInvolves / agreementPartner handle both parties and from/to shapes', () => {
     const dmz = { type: 'dmz', parties: ['france', 'italy'], provinces: ['pie'] };
     const support = { type: 'support', from: 'france', to: 'germany' };
@@ -162,5 +173,55 @@ describe('getters', () => {
     expect(agreementPartner(support, 'france')).toBe('germany');
     expect(agreementPartner(support, 'germany')).toBe('france');
     expect(agreementPartner(support, 'italy')).toBeNull();
+  });
+});
+
+describe('setScratchpad / setSummary (#44 carried memory)', () => {
+  const board = new DiplomacyBoard();
+  const base = createDiplomaticState({ board, humanPower: 'england' });
+  const pad = {
+    self: 'france',
+    dispositions: { germany: { trust: -0.3, stance: 'rival', intent: 'Stab in fall.' } },
+    priority: 'Take Belgium.',
+    confidence: 0.6,
+  };
+
+  test('setScratchpad stores per power and is pure', () => {
+    const before = JSON.parse(JSON.stringify(base));
+    const next = setScratchpad(base, 'france', pad);
+    expect(getScratchpad(next, 'france')).toEqual(pad);
+    expect(base).toEqual(before); // input untouched
+  });
+
+  test('setScratchpad with null clears the entry', () => {
+    let s = setScratchpad(base, 'france', pad);
+    s = setScratchpad(s, 'france', null);
+    expect(getScratchpad(s, 'france')).toBeNull();
+  });
+
+  test('setScratchpad ignores a missing power', () => {
+    expect(setScratchpad(base, '', pad)).toBe(base);
+  });
+
+  test('setSummary stores per channel and trims', () => {
+    const next = setSummary(base, 'austria~france', '  Tense over Galicia.  ');
+    expect(getSummary(next, 'austria~france')).toBe('Tense over Galicia.');
+  });
+
+  test('setSummary ignores empty, non-string, or oversized text (no-op)', () => {
+    expect(setSummary(base, 'a~b', '')).toBe(base);
+    expect(setSummary(base, 'a~b', 42)).toBe(base);
+    expect(setSummary(base, 'a~b', 'x'.repeat(201))).toBe(base);
+    // 200 chars exactly is allowed.
+    const ok = setSummary(base, 'a~b', 'y'.repeat(200));
+    expect(getSummary(ok, 'a~b').length).toBe(200);
+  });
+
+  test('summaries/scratchpads survive a JSON serialize/deserialize round trip', () => {
+    let s = setScratchpad(base, 'france', pad);
+    s = setSummary(s, 'austria~france', 'Holding the DMZ.');
+    const round = JSON.parse(JSON.stringify(s));
+    expect(getScratchpad(round, 'france')).toEqual(pad);
+    expect(getSummary(round, 'austria~france')).toBe('Holding the DMZ.');
   });
 });

--- a/src/games/diplomacy/agents/endpoint.test.js
+++ b/src/games/diplomacy/agents/endpoint.test.js
@@ -195,6 +195,48 @@ describe('diplomacyAgent endpoint', () => {
     expect(res.statusCode).toBe(502);
   });
 
+  test('an emitted summary (<=200 chars) is returned; oversized/absent become empty', async () => {
+    // Valid summary surfaces.
+    global.fetch = mockUpstreamText(JSON.stringify({ message: 'Aligned.', scratchpad: VALID_SCRATCHPAD, summary: 'DMZ in the Channel holds.' }));
+    let res = makeRes();
+    await handler(makeReq({ body: { apiKey: 'sk-test', power: 'france', messages: [{ role: 'user', content: 'hi' }] } }), res);
+    expect(res.body.summary).toBe('DMZ in the Channel holds.');
+
+    // Oversized summary is dropped to ''.
+    global.fetch = mockUpstreamText(JSON.stringify({ message: 'Aligned.', scratchpad: VALID_SCRATCHPAD, summary: 'x'.repeat(201) }));
+    res = makeRes();
+    await handler(makeReq({ body: { apiKey: 'sk-test', power: 'france', messages: [{ role: 'user', content: 'hi' }] } }), res);
+    expect(res.body.summary).toBe('');
+
+    // Absent summary is ''.
+    global.fetch = mockUpstreamText(JSON.stringify({ message: 'Aligned.', scratchpad: VALID_SCRATCHPAD }));
+    res = makeRes();
+    await handler(makeReq({ body: { apiKey: 'sk-test', power: 'france', messages: [{ role: 'user', content: 'hi' }] } }), res);
+    expect(res.body.summary).toBe('');
+  });
+
+  test('prior memory (priorSummary/memory) is injected into the system prompt', async () => {
+    global.fetch = mockUpstreamText(JSON.stringify({ message: 'Understood.', scratchpad: VALID_SCRATCHPAD }));
+    const res = makeRes();
+    await handler(
+      makeReq({
+        body: {
+          apiKey: 'sk-test',
+          power: 'france',
+          messages: [{ role: 'user', content: 'hi' }],
+          priorSummary: 'We agreed to a Channel DMZ last phase.',
+          memory: 'stance rival; intent: lure into NTH',
+        },
+      }),
+      res
+    );
+    const payload = JSON.parse(global.fetch.mock.calls[0][1].body);
+    const systemText = payload.system[0].text;
+    expect(systemText).toContain('We agreed to a Channel DMZ last phase.');
+    expect(systemText).toContain('Previously with this rival:');
+    expect(systemText).toContain('lure into NTH');
+  });
+
   test('a thrown error returns a generic 500 that never echoes the request body', async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('network down'));
     const res = makeRes();

--- a/src/games/diplomacy/agents/negotiator.js
+++ b/src/games/diplomacy/agents/negotiator.js
@@ -19,7 +19,15 @@ import {
   FLEET_ADJACENCY,
   baseProvince,
 } from '../DiplomacyBoard.js';
-import { recordPromise, recordAgreement, getTrust } from './diplomaticState.js';
+import {
+  recordPromise,
+  recordAgreement,
+  getTrust,
+  setScratchpad,
+  setSummary,
+  getScratchpad,
+  getSummary,
+} from './diplomaticState.js';
 
 // --- deterministic RNG (mulberry32) -----------------------------------------
 // Seeded so pair selection / tie-breaking is reproducible across runs.
@@ -221,6 +229,23 @@ function channelId(a, b) {
   return [a, b].sort().join('~');
 }
 
+// --- prior-memory injection (#44) -------------------------------------------
+
+// Render a power's persisted disposition toward one rival into a short private
+// note line (for re-injection as `memory`). Empty string when nothing is known.
+function priorNoteFor(state, power, rival) {
+  const scratchpad = getScratchpad(state, power);
+  if (!scratchpad || !scratchpad.dispositions) return '';
+  const d = scratchpad.dispositions[rival];
+  if (!d || typeof d !== 'object') return '';
+  const parts = [];
+  if (d.stance) parts.push(`stance ${d.stance}`);
+  if (typeof d.trust === 'number') parts.push(`trust ${d.trust.toFixed(2)}`);
+  if (d.intent) parts.push(`intent: ${d.intent}`);
+  if (d.note) parts.push(`note: ${d.note}`);
+  return parts.join('; ');
+}
+
 // --- orchestrator -----------------------------------------------------------
 
 const DEFAULT_OPTIONS = { maxRounds: 2, maxPairsPerRound: 4, humanPower: null, seed: 0 };
@@ -233,8 +258,10 @@ const DEFAULT_OPTIONS = { maxRounds: 2, maxPairsPerRound: 4, humanPower: null, s
 //             `agents.humanThreads` (if present) is the HUMAN-VISIBLE thread store
 //             and is NEVER written with AI↔AI text.
 //   askAgent: async ({ power, counterparties, channel, boardContext, persona,
-//             memory, scratchpad, messages }) -> { reply, scratchpadDelta? }.
-//             Injected so tests mock it; the app passes the reused endpoint client.
+//             priorSummary, memory, scratchpad, messages }) ->
+//             { reply: { message, scratchpad?, summary? } }. Injected so tests
+//             mock it; the app passes the reused endpoint client. The orchestrator
+//             folds reply.scratchpad/summary into the returned state (#44).
 //   options:  { maxRounds, maxPairsPerRound, humanPower, seed }.
 //
 // Budget (hard): ≤ maxRounds × maxPairsPerRound AI↔AI askAgent calls, plus ≤ 1
@@ -279,8 +306,12 @@ export async function runNegotiationPhase({ board, state, agents = {}, askAgent,
         phase,
         boardContext: aCtx.boardContext || null,
         persona: aCtx.persona || null,
-        memory: aCtx.memory || null,
-        scratchpad: aCtx.scratchpad || null,
+        // Carry the conversation forward (#44): the brief per-channel summary and
+        // this power's own prior private note about the rival, both from the
+        // persisted diplomatic state (never the human-visible store).
+        priorSummary: getSummary(nextState, channel),
+        memory: priorNoteFor(nextState, a, b),
+        scratchpad: getScratchpad(nextState, a),
         messages: transcriptMessages(transcripts[channel], a),
       });
 
@@ -291,6 +322,18 @@ export async function runNegotiationPhase({ board, state, agents = {}, askAgent,
         counterparty: b,
         message: messageText(proposalReply),
       });
+
+      // Persist the proposer's scratchpad + the channel summary so they carry
+      // into the next phase. These live ONLY in the hidden diplomatic state —
+      // never written to agents.humanThreads (the secrecy invariant).
+      if (proposalReply && typeof proposalReply === 'object') {
+        if (proposalReply.scratchpad) {
+          nextState = setScratchpad(nextState, a, proposalReply.scratchpad);
+        }
+        if (proposalReply.summary) {
+          nextState = setSummary(nextState, channel, proposalReply.summary);
+        }
+      }
 
       // Record any concrete, structured deal the proposer offered AND the
       // counterparty implicitly/explicitly accepted (acceptance is the proposer
@@ -315,15 +358,19 @@ export async function runNegotiationPhase({ board, state, agents = {}, askAgent,
       // Skip if the last message is already from the AI (nothing to answer).
       if (thread.messages[thread.messages.length - 1].role === 'assistant') continue;
 
+      const humanChannel = `human~${power}`;
       const res = await askAgent({
         power,
         counterparties: [human],
-        channel: `human~${power}`,
+        channel: humanChannel,
         phase,
         boardContext: ctx.boardContext || null,
         persona: ctx.persona || null,
-        memory: ctx.memory || null,
-        scratchpad: ctx.scratchpad || null,
+        // The human thread carries its own summary + this power's prior note
+        // about the human, mirroring the AI↔AI continuity (#44).
+        priorSummary: getSummary(nextState, humanChannel),
+        memory: priorNoteFor(nextState, power, human),
+        scratchpad: getScratchpad(nextState, power),
         messages: thread.messages,
       });
       const reply = res && res.reply ? res.reply : res;
@@ -331,6 +378,13 @@ export async function runNegotiationPhase({ board, state, agents = {}, askAgent,
       if (text && humanThreads) {
         thread.messages.push({ role: 'assistant', content: text, turn: phase || '' });
         thread.updatedAt = Date.now();
+      }
+      // Persist the power's evolving scratchpad (and the human-channel summary)
+      // into the HIDDEN state only — the visible text already went to the thread
+      // above; the private disposition/summary never touch humanThreads.
+      if (reply && typeof reply === 'object') {
+        if (reply.scratchpad) nextState = setScratchpad(nextState, power, reply.scratchpad);
+        if (reply.summary) nextState = setSummary(nextState, humanChannel, reply.summary);
       }
     }
   }

--- a/src/games/diplomacy/agents/negotiator.test.js
+++ b/src/games/diplomacy/agents/negotiator.test.js
@@ -1,5 +1,5 @@
 import DiplomacyBoard from '../DiplomacyBoard.js';
-import { createDiplomaticState } from './diplomaticState.js';
+import { createDiplomaticState, getScratchpad, getSummary } from './diplomaticState.js';
 import { createMemory } from './memory.js';
 import { runNegotiationPhase, selectPairs } from './negotiator.js';
 
@@ -158,6 +158,110 @@ describe('runNegotiationPhase — deal extraction', () => {
     });
     expect(next.promises).toHaveLength(0);
     expect(next.agreements).toHaveLength(0);
+  });
+});
+
+describe('runNegotiationPhase — carried memory (#44)', () => {
+  test('a scratchpad returned in phase N is present in the state used for phase N+1', async () => {
+    const { board, state, humanPower } = freshGame();
+    const opts = { maxRounds: 1, maxPairsPerRound: 4, humanPower, seed: 5 };
+
+    const pad = {
+      self: 'self',
+      dispositions: { rival: { trust: -0.4, stance: 'rival', intent: 'Stab next fall.' } },
+      priority: 'Grow.',
+      confidence: 0.7,
+    };
+    const askN = mockAskAgent((power) => {
+      if (askN.calls.length === 1) {
+        return { message: 'Friends for now.', scratchpad: { ...pad, self: power } };
+      }
+      return { message: '' };
+    });
+    const { state: afterN } = await runNegotiationPhase({ board, state, askAgent: askN, options: opts });
+
+    const firstProposer = askN.calls[0].power;
+    expect(getScratchpad(afterN, firstProposer)).toMatchObject({ self: firstProposer });
+
+    // Phase N+1: the orchestrator re-injects that power's prior note about its
+    // rival as `memory`, observable on the askAgent call args.
+    const rivalInChannel = askN.calls[0].counterparties[0];
+    const padForNext = {
+      self: firstProposer,
+      dispositions: { [rivalInChannel]: { trust: -0.4, stance: 'rival', intent: 'Stab next fall.' } },
+      priority: 'Grow.',
+      confidence: 0.7,
+    };
+    const seeded = JSON.parse(JSON.stringify(afterN));
+    seeded.scratchpads[firstProposer] = padForNext;
+
+    const askNext = mockAskAgent(() => ({ message: '' }));
+    await runNegotiationPhase({ board, state: seeded, askAgent: askNext, options: opts });
+    const proposerCall = askNext.calls.find(
+      (c) => c.power === firstProposer && (c.counterparties || []).includes(rivalInChannel)
+    );
+    expect(proposerCall).toBeTruthy();
+    expect(proposerCall.memory).toContain('Stab next fall.');
+    expect(proposerCall.memory).toContain('rival');
+  });
+
+  test('a channel summary is captured and re-injected as priorSummary next phase', async () => {
+    const { board, state, humanPower } = freshGame();
+    const opts = { maxRounds: 1, maxPairsPerRound: 4, humanPower, seed: 5 };
+
+    const askN = mockAskAgent(() => {
+      if (askN.calls.length === 1) {
+        return { message: 'Belgium stays neutral.', summary: 'Agreed to keep Belgium neutral.' };
+      }
+      return { message: '' };
+    });
+    const { state: afterN } = await runNegotiationPhase({ board, state, askAgent: askN, options: opts });
+
+    const firstChannel = askN.calls[0].channel;
+    expect(getSummary(afterN, firstChannel)).toBe('Agreed to keep Belgium neutral.');
+
+    const askNext = mockAskAgent(() => ({ message: '' }));
+    await runNegotiationPhase({ board, state: afterN, askAgent: askNext, options: opts });
+    const call = askNext.calls.find((c) => c.channel === firstChannel);
+    expect(call).toBeTruthy();
+    expect(call.priorSummary).toBe('Agreed to keep Belgium neutral.');
+  });
+
+  test('AI↔AI scratchpads/summaries are NEVER written to the human thread store', async () => {
+    const { board, state, humanPower } = freshGame();
+    const aiPowers = board.getPowerIds().filter((p) => p !== humanPower);
+    const humanThreads = createMemory(aiPowers);
+
+    const PAD_SECRET = 'PAD-SECRET-STAB-PLAN';
+    const SUM_SECRET = 'SUMMARY-SECRET-DMZ-PLAN';
+    const askAgent = mockAskAgent((power, ctx) => {
+      if (!ctx.channel.startsWith('human~')) {
+        return {
+          message: 'Pleasant nothing.',
+          scratchpad: {
+            self: power,
+            dispositions: { [ctx.counterparties[0]]: { trust: -0.2, stance: 'enemy', intent: PAD_SECRET } },
+            priority: 'win',
+            confidence: 0.5,
+          },
+          summary: SUM_SECRET,
+        };
+      }
+      return { message: 'Nothing to report.' };
+    });
+
+    const { state: next } = await runNegotiationPhase({
+      board, state, askAgent,
+      agents: { humanThreads },
+      options: { maxRounds: 2, maxPairsPerRound: 4, humanPower, seed: 11 },
+    });
+
+    const hidden = JSON.stringify({ scratchpads: next.scratchpads, summaries: next.summaries });
+    expect(hidden).toContain(PAD_SECRET);
+    expect(hidden).toContain(SUM_SECRET);
+    const visible = JSON.stringify(humanThreads);
+    expect(visible).not.toContain(PAD_SECRET);
+    expect(visible).not.toContain(SUM_SECRET);
   });
 });
 


### PR DESCRIPTION
## Summary
Closes three agent-fidelity gaps in the Diplomacy conversational layer (all three PRs from #44 in one branch): private negotiation now carries forward across phases, the LLM's private "thinking" reaches the order pipeline (ledger-dominant), and betrayal is decided per deal instead of all-or-nothing.

Closes #44

- **PR1 — continuity (no extra LLM call):** `api/diplomacyAgent.js` gains an optional `summary` field (parsed defensively, ignored if absent/oversized) and injects `priorSummary`/`memory` into the system prompt. `diplomaticState.js` gains `scratchpads`/`summaries` with pure setters/getters. `negotiator.js` persists each AI↔AI proposer's scratchpad + channel summary into the hidden state and re-injects them next phase; human-thread replies persist that power's scratchpad too. AI↔AI scratchpads/summaries are never written to the human-visible thread store. `agentClient.js` threads `priorSummary`/`memory` and surfaces `summary`.
- **PR2 — thinking → orders:** `decideStrategicIntent` blends ledger + scratchpad trust via `effectiveTrust = clamp(W_LEDGER·ledger + W_SCRATCH·scratch, -1, 1)` with `W_LEDGER` (0.7) > `W_SCRATCH` (0.3). A hostile scratchpad stance presses a deal-less rival; a friendly stance keeps them out of targets unless the ledger disagrees.
- **PR3 — deal-specific payoff:** `payoffOfBreaking(board, power, agreement)` partitions candidate plans into honor-consistent vs free and uses the per-agreement gain instead of one global number; holding baseline when no honor-consistent plan exists. Injected `payoff` override preserved.

## Validation evidence

### Tests
`CI=true npm test` — full suite green (40 suites, 796 tests). New tests cover: scratchpad carry-forward across phases, summary capture + re-injection (asserted via mocked `askAgent` receiving `priorSummary`/`memory`), the secrecy negative test extended to scratchpads/summaries, serialize/deserialize round-trip, the ledger-dominant trust blend, hostile-scratchpad targeting, deal-specific payoff (low vs high constraint, two deals resolving differently same turn, injected override), determinism. The LLM (`askAgent`) is mocked everywhere — no real key in CI.

### Manual verification
`npm run build` — completes without errors. BYO-key invariants on `api/diplomacyAgent.js` verified unchanged: no `process.env`, no `console.*`, one upstream call, error handler omits the body. No `DiplomacyBoard.js` edits; no cross-game imports.

## Affected areas
- **Files changed:** `api/diplomacyAgent.js`, `src/games/diplomacy/agents/{diplomaticState,negotiator,agentClient,betrayalModel}.js` (+ their tests), `src/games/diplomacy/agents/endpoint.test.js`, `docs/diplomacy.md`
- **Dependencies:** none

## Review focus
- The ledger-dominant trust blend and the deal-less scratchpad targeting rule in `betrayalModel.js`.
- `payoffOfBreaking` honor-predicate correctness (note: province ids are compared case-insensitively — agreements store lower-case, board move targets are upper-case).
- The secrecy invariant: AI↔AI scratchpads/summaries stay in `diplomaticState` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)