### PR TITLE
fix(splendor): restore player discount colors

### DIFF
--- a/src/games/splendor/splendor.css
+++ b/src/games/splendor/splendor.css
@@ -180,7 +180,7 @@
 .gem-gold   { --chip: #d6a341; --spot: #fff0c0; color: #3a2906; }
 
 /* Small gems (card cost/bonus, player holdings, noble reqs): flat matte tiles. */
-.spl-cost-pip, .spl-card-bonus, .spl-gemstack-bonus, .spl-noble-pip {
+.spl-cost-pip, .spl-card-bonus, .spl-gemstack-bonus, .spl-noble-pip, .spl-hero-bonus {
   background: var(--chip);
   box-shadow: var(--gem-edge);
 }


### PR DESCRIPTION
## Summary
- include the player's discount indicators in the shared gem tile styles
- restore each discount's `--chip` background color and gem edge shadow

## Testing
- `CI=true npm test -- --runInBand` (51 suites, 948 tests)
- `npm run build`